### PR TITLE
Restore functionality of the special_rights view.

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -906,8 +906,8 @@ def get_user(username):
 @require_permission('user_edit')
 @templated('portal/special_rights.html')
 def users_with_special_rights(request):
-    users = User.objects.filter(privilege__user=None).distinct() \
-                        .order_by('username')
+    users = User.objects.filter(privilege__isnull=False).distinct()\
+                .order_by('username').defer('settings')
     return {
         'users': users,
         'count': len(users),


### PR DESCRIPTION
The query now actually returns correct results and only uses an outer join
instead of subselects.

---

For extra fun: View the query in debug toolbar before and after the fix
