### PR TITLE
update the username in the admin user profile form

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -942,13 +942,14 @@ def user_edit_profile(request, username):
         form = EditUserProfileForm(request.POST, request.FILES, user=user)
         if form.is_valid():
             data = form.cleaned_data
+
             lat = data.get('coordinates_lat', None)
             long = data.get('coordinates_long', None)
             data['coordinates'] = '%s, %s' % (lat, long) if lat and long else ''
             for key in ('website', 'interests', 'location', 'jabber', 'icq',
                          'msn', 'aim', 'yim', 'signature', 'coordinates',
                          'gpgkey', 'email', 'skype', 'sip', 'wengophone',
-                         'launchpad', 'member_title'):
+                         'launchpad', 'member_title', 'username'):
                 setattr(user, key, data[key] or '')
             if data['delete_avatar']:
                 user.delete_avatar()


### PR DESCRIPTION
Ticket: http://trac.inyokaproject.org/ticket/615

To allow a renaming even if the mail address is invalid enforces a much more complex `form.is_valid()` handling. The check for a blocked host is part of the `inyoka.utils.forms.EmailField()`. We cannot access the username from this part of the code to check against a user rename. I think the easiest solution is to drop the error from the form if the username is changed and to continue the _normal_ process.
