### PR TITLE
fix i18n for userpages.

### DIFF
--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -135,6 +135,10 @@ WIKI_DISCUSSION_FORUM = 'discussions'
 # rules
 WIKI_TEMPLATE_BASE = 'Wiki/Templates'
 
+# the base page of all user wiki pages
+WIKI_USER_BASE = 'User'
+WIKI_USERPAGE_INFO = 'Userpage'
+
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = 'b)l0ju3erxs)od$g&l_0i1za^l+2dwgxuay(nwv$q4^*c#tdwt'
 

--- a/inyoka/portal/templates/portal/profile.html
+++ b/inyoka/portal/templates/portal/profile.html
@@ -166,7 +166,7 @@
   {%- if wikipage %}
     {{ wikipage }}
     <p>
-      (<a href="{{ href('wiki', 'Benutzer', user.username|e, action='edit') }}">{% trans %}edit{% endtrans %}</a>)
+      (<a href="{{ href('wiki', SETTINGS.WIKI_USER_BASE, user.username|e, action='edit') }}">{% trans %}edit{% endtrans %}</a>)
     </p>
   {%- endif %}
 {% endblock %}

--- a/inyoka/portal/templates/portal/user_overview.html
+++ b/inyoka/portal/templates/portal/user_overview.html
@@ -33,10 +33,6 @@
         {{ user_edit_button(href('portal', 'user', user.urlsafe_username, 'edit', 'privileges'), 'privileges', _('Privileges')) }}
         {{ user_edit_button(href('portal', 'user', user.urlsafe_username, 'edit', 'password'), 'password', _('Change password')) }}
         {{ user_edit_button(href('portal', 'user', user.urlsafe_username, 'edit', 'status'), 'status', _('State')) }}
-        {#
-        {{ user_edit_button(href('portal', 'user', user.username, 'edit', 'subscriptions'), 'subscriptions', 'Abonnements') }}
-        {{ user_edit_button(href('portal', 'user', user.username, 'edit', 'userpage'), 'wikipage', 'Benutzerseite') }}
-        #}
       </ul>
     </div>
     <a href="{{ href('portal', 'user', user.username) }}">{% trans %}View public profile{% endtrans %}</a>

--- a/inyoka/portal/templates/portal/usercp/index.html
+++ b/inyoka/portal/templates/portal/usercp/index.html
@@ -27,11 +27,10 @@
       {{ usercp_button(href('portal', 'usercp', 'password'), 'password', _('Change password')) }}
       {{ usercp_button(href('portal', 'usercp', 'subscriptions'), 'subscriptions', _('Subscriptions')) }}
       {{ usercp_button(href('portal', 'usercp', 'deactivate'), 'deactivate', _('Deactivate account')) }}
-      {# TODO SETTING.??? #}
       {% if user.has_wikipage -%}
-        {{ usercp_button(href('wiki', 'Benutzer', user.username|e, action='edit'), 'wikipage', _('User page')) }}
+        {{ usercp_button(href('wiki', SETTINGS.WIKI_USER_BASE, USER.username|e, action='edit'), 'wikipage', _('User page')) }}
       {%- else -%}
-        {{ usercp_button(href('wiki', 'Benutzerseite'), 'wikipage', _('User page')) }}
+        {{ usercp_button(href('wiki', SETTINGS.WIKI_USERPAGE_INFO), 'wikipage', _('User page')) }}
       {%- endif %}
     </ul>
   </div>

--- a/inyoka/portal/templates/portal/usercp/overall.html
+++ b/inyoka/portal/templates/portal/usercp/overall.html
@@ -21,11 +21,10 @@
       <li><a href="{{ href('portal', 'usercp', 'subscriptions') }}"{{ selected == 'subscriptions' and ' class="active"' or '' }}>{% trans %}Subscriptions{% endtrans %}</a></li>
       <li><a href="{{ href('portal', 'usercp', 'deactivate') }}"{{ selected == 'deactivate' and ' class="active"' or '' }}>{% trans %}Deactivate account{% endtrans %}</a></li>
       <li>
-        {#- TODO SETTING.??? -#}
         {%- if USER.has_wikipage -%}
-          <a href="{{ href('wiki', 'Benutzer', USER.username|e, action='edit') }}">
+          <a href="{{ href('wiki', SETTINGS.WIKI_USER_BASE, USER.username|e, action='edit') }}">
         {%- else -%}
-          <a href="{{ href('wiki', 'Benutzerseite') }}">
+          <a href="{{ href('wiki', SETTINGS.WIKI_USERPAGE_INFO) }}">
         {%- endif -%}
         {% trans %}User page{% endtrans %}</a>
       </li>

--- a/inyoka/portal/user.py
+++ b/inyoka/portal/user.py
@@ -110,7 +110,8 @@ def reactivate_user(id, email, status, time):
 
     # reactivate user page
     try:
-        userpage = WikiPage.objects.get_by_name('Benutzer/%s' % escape(user.username))
+        userpage = WikiPage.objects.get_by_name('%s/%s' % (
+                settings.WIKI_USER_BASE, escape(user.username)))
         userpage.edit(user=User.objects.get_system_user(), deleted=False,
                       note=_(u'The user “%(name)s“ has reactivated his account.')
                              % {'name': escape(user.username)})
@@ -153,7 +154,8 @@ def deactivate_user(user):
 
     # delete user wiki page
     try:
-        userpage = WikiPage.objects.get_by_name('Benutzer/%s' % escape(user.username))
+        userpage = WikiPage.objects.get_by_name('%s/%s' % (
+                settings.WIKI_USER_BASE, escape(user.username)))
         userpage.edit(user=User.objects.get_system_user(), deleted=True,
                       note=_(u'The user “%(name)s“ has deactivated his account.')
                              % {'name': escape(user.username)})
@@ -591,7 +593,8 @@ class User(models.Model):
         Returns the rendered wikipage if it exists, otherwise None
         """
         from inyoka.wiki.models import Page as WikiPage
-        key = 'Benutzer/' + normalize_pagename(self.username)
+        key = '%s/%s' % (settings.WIKI_USER_BASE,
+                         normalize_pagename(self.username))
         return WikiPage.objects.exists(key)
 
     def email_user(self, subject, message, from_email=None):

--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -523,8 +523,8 @@ def profile(request, username):
         raise PageNotFound()
 
     try:
-        # TODO: remove hardcoded wikipage
-        key = 'Benutzer/' + normalize_pagename(user.username)
+        key = '%s/%s' % (settings.WIKI_USER_BASE,
+                         normalize_pagename(user.username))
         wikipage = WikiPage.objects.get_by_name(key, raise_on_deleted=True)
         content = wikipage.rev.rendered_text
     except WikiPage.DoesNotExist:
@@ -888,8 +888,8 @@ def usercp_userpage(request):
     """
     flash(_(u'You were redirected to our wiki to change your user page. To get '
             u'back, you can use the link or your browser’s “back“ button.'))
-    # TODO: hardcoded wikipage
-    return HttpResponseRedirect(href('wiki', 'Benutzer', request.user.username, action='edit'))
+    return HttpResponseRedirect(href('wiki', settings.WIKI_USER_BASE,
+                                     request.user.username, action='edit'))
 
 
 def get_user(username):


### PR DESCRIPTION
This commit introduces two system-variables `WIKI_USER_BASE` and `WIKI_USERPAGE_INFO`.

The former is the base path to all userpages, e.g. for user 'foo' it will be 'wiki.example.com/User/foo' by default. The information page about userpages is defined by the latter one which expands to 'wiki.example.com/Userpage' by default.
