### PR TITLE
Get rid of the ugly underlines in links

### DIFF
--- a/inyoka/forum/templates/forum/edit.html
+++ b/inyoka/forum/templates/forum/edit.html
@@ -35,7 +35,7 @@
 {% block forum_content %}
   <form action="" method="post" enctype="multipart/form-data" class="post_editor">
     <a href="{{ href('pastebin') }}" class="pastelink" title="{% trans %}Please save long code snippets or program outputs in our paste service and link to the respective entry.{% endtrans %}">
-      {% trans %}Paste{% endtrans %}
+      {%- trans %}Paste{% endtrans -%}
     </a>
     {%- if topic %}
       {%- if post %}

--- a/inyoka/forum/templates/forum/forum.html
+++ b/inyoka/forum/templates/forum/forum.html
@@ -110,9 +110,9 @@
                 » <span class="ubuntu_version">{{ topic.get_version_info() }}</span>
               {%- endif %}
               {%- if not topic.get_read_status(USER) %}
-                <a href="{{ topic|url('first_unread') }}" title="{% trans %}Show unread posts{% endtrans %}">
-                  <img src="{{ href('static', 'img/forum/goto.png') }}" alt="{% trans %}Show unread posts{% endtrans %}" />
-                </a>
+                <a href="{{ topic|url('first_unread') }}" title="{% trans %}Show unread posts{% endtrans %}">{#
+                  #}<img src="{{ href('static', 'img/forum/goto.png') }}" alt="{% trans %}Show unread posts{% endtrans %}" />{#
+                #}</a>
               {%- endif %}
             </p>
             <p class="description note">
@@ -132,7 +132,7 @@
           <td class="last_post">
             {%- if topic.last_post_id %}
               <a href="{{ topic.last_post|url}}" class="date">
-                {{ topic.last_post.pub_date|datetimeformat }}
+                {{- topic.last_post.pub_date|datetimeformat -}}
               </a><br />
               {% trans author=topic.last_post.author|e, link=topic.last_post.author|url -%}
                 by <a href="{{ link }}">{{ author }}</a>

--- a/inyoka/forum/templates/forum/forum.m.html
+++ b/inyoka/forum/templates/forum/forum.m.html
@@ -26,8 +26,8 @@
   <div class="topics">
     <h3>{% trans %}Topics{% endtrans %}</h3>
     {%- for topic in topics if (topic.first_post and topic.last_post) %}
-      <a href="{{ topic|url }}">
-        <div class="button
+      <a href="{{ topic|url }}">{#
+        #}<div class="button
             {% if not topic.get_read_status(USER) %} unread{% endif %}
             {% if topic.solved %} solved{% endif %}
             {% if topic.hidden %} hidden{% endif %}
@@ -35,10 +35,10 @@
             {% if topic.sticky %} sticky{% endif %}
             {% if topic.has_poll %} poll{% endif %}
             {% if topic.locked %} locked{% endif %}">
-          {% if topic.sticky %}<strong>{% trans %}Sticky:{% endtrans %}</strong>{% endif %}
-          {{ topic.title|e }}
-        </div>
-      </a>
+        {%- if topic.sticky %}<strong>{% trans %}Sticky:{% endtrans %}</strong>{% endif -%}
+          {{ topic.title|e -}}
+        </div>{#
+      #}</a>
     {%- endfor %}
   </div>
   {{ pagination.generate() }}

--- a/inyoka/forum/templates/forum/reportlist.html
+++ b/inyoka/forum/templates/forum/reportlist.html
@@ -72,11 +72,11 @@
     <input type="submit" value="{% trans %}Close selected tickets{% endtrans %}" /> |
     {%- if subscribed %}
       <a href="{{ href('forum', 'reported_topics', 'unsubscribe') }}">
-        {% trans %}Unsubscribe from topic reports{% endtrans %}
+        {%- trans %}Unsubscribe from topic reports{% endtrans -%}
       </a>
     {%- else %}
       <a href="{{ href('forum', 'reported_topics', 'subscribe') }}">
-        {% trans %}Subscribe to topic reports{% endtrans %}
+        {%- trans %}Subscribe to topic reports{% endtrans -%}
       </a>
     {%- endif %}
   </div>

--- a/inyoka/forum/templates/forum/splittopic.html
+++ b/inyoka/forum/templates/forum/splittopic.html
@@ -74,9 +74,9 @@
               <div class="postinfo">
                 <div class="linklist">
                 </div>
-                <a href="{{ post|url }}" title="Kopiere diesen Link, um auf diesen Beitrag zu verweisen" onclick="alert(this.title + '\n\n' + this.href); return false">
-                  <img src="{{ href('static', 'img', 'icon_minipost.gif') }}" alt="{% trans %}Post{% endtrans %}" />
-                </a>
+                <a href="{{ post|url }}" title="Kopiere diesen Link, um auf diesen Beitrag zu verweisen" onclick="alert(this.title + '\n\n' + this.href); return false">{#
+                  #}<img src="{{ href('static', 'img', 'icon_minipost.gif') }}" alt="{% trans %}Post{% endtrans %}" />{#
+                #}</a>
                 {{ post.pub_date|datetimeformat }}
               </div>
               <div class="text">

--- a/inyoka/forum/templates/forum/topic.m.html
+++ b/inyoka/forum/templates/forum/topic.m.html
@@ -110,20 +110,20 @@
   </section>
   {{ pagination.generate() }}
   <section class="actions">
-    <a href="{{ topic|url('reply')}}">
-      <span>{% trans %}Reply{% endtrans %}</span>
-    </a>
+    <a href="{{ topic|url('reply')}}">{#
+      #}<span>{% trans %}Reply{% endtrans %}</span>{#
+    #}</a>
     {% if is_subscribed %}
-      <a href="{{ topic|url('unsubscribe')}}">
-        <span>{% trans %}Unsubscribe{% endtrans %}</span>
-      </a>
+      <a href="{{ topic|url('unsubscribe')}}">{#
+        #}<span>{% trans %}Unsubscribe{% endtrans %}</span>{#
+      #}</a>
     {% else %}
-      <a href="{{ topic|url('subscribe')}}">
-        <span>{% trans %}Subscribe{% endtrans %}</span>
-      </a>
+      <a href="{{ topic|url('subscribe')}}">{#
+        #}<span>{% trans %}Subscribe{% endtrans %}</span>{#
+      #}</a>
     {% endif %}
-    <a href="{{ topic|url('report')}}">
-      <span>{% trans %}Report{% endtrans %}</span>
-    </a>
+    <a href="{{ topic|url('report')}}">{#
+      #}<span>{% trans %}Report{% endtrans %}</span>{#
+    #}</a>
   </section>
 {% endblock %}

--- a/inyoka/forum/templates/forum/topiclist.html
+++ b/inyoka/forum/templates/forum/topiclist.html
@@ -69,10 +69,10 @@
               <a href="{{ topic|url }}">{{ topic.title|e }}</a>
               {%- if not topic.get_read_status(USER) %}
                 <a href="{{ topic|url('first_unread') }}"
-                   title="{% trans %}Show unread posts{% endtrans %}">
-                  <img src="{{ href('static', 'img/forum/goto.png') }}"
-                       alt="{% trans %}Show unread posts{% endtrans %}" />
-                </a>
+                   title="{% trans %}Show unread posts{% endtrans %}">{#
+                  #}<img src="{{ href('static', 'img/forum/goto.png') }}"
+                         alt="{% trans %}Show unread posts{% endtrans %}" />{#
+                #}</a>
               {%- endif %}
             </p>
             <p class="description note">

--- a/inyoka/planet/templates/planet/index.html
+++ b/inyoka/planet/templates/planet/index.html
@@ -37,9 +37,9 @@
           {% for article in day.articles %}
             <div class="article admin_link_hover" id="article_{{ article_index + loop.index0 }}">
               <div class="head">
-                <a href="{{ article.blog|url|e }}">
-                  <img src="{{ article.blog.icon_url|e }}" alt="" /><br />
-                </a>
+                <a href="{{ article.blog|url|e }}">{#
+                  #}<img src="{{ article.blog.icon_url|e }}" alt="" /><br />{#
+                #}</a>
                 <p>
                   <a href="{{ article.blog|url|e }}">{{ article.blog.name|e }}</a>
                   {{ article.pub_date|datetimeformat }}

--- a/inyoka/portal/templates/portal/privmsg/index.html
+++ b/inyoka/portal/templates/portal/privmsg/index.html
@@ -80,17 +80,17 @@
             </td>
             <td>
               <a{% if not entry.message.author.is_active %} class="user_inactive"{% endif %} href="{{ entry.message.author|url }}">
-                    {{- entry.message.author|e }}
+                    {{- entry.message.author|e -}}
               </a>
             </td>
             <td>
               {%- if entry.message.recipients|length == 0 %}
                 <a{% if not entry.message.author.is_active %} class="user_inactive"{% endif %} href="{{ entry.message.author|url }}">
-                  {{- entry.message.author|e }}
+                  {{- entry.message.author|e -}}
                 </a>
               {% else %}
                 <a{% if not entry.message.recipients[0].is_active %} class="user_inactive"{% endif %} href="{{ entry.message.recipients[0]|url }}">
-                  {{- entry.message.recipients[0]|e }}
+                  {{- entry.message.recipients[0]|e -}}
                 </a>
               {%- endif %}
               {%- if entry.message.recipients|length > 1 %}, …{% endif %}
@@ -99,23 +99,23 @@
             <td class="actions">
               {%- if not entry.is_own_message %}
                 {% if entry.message.author.is_active %}
-                  <a href="{{ entry|url('reply') }}" title="{% trans %}Reply{% endtrans %}">
-                    <img src="{{ href('static', 'img/icons/small/msg-reply.png') }}" alt="{% trans %}Reply{% endtrans %}" />
-                  </a>
+                  <a href="{{ entry|url('reply') }}" title="{% trans %}Reply{% endtrans %}">{#
+                    #}<img src="{{ href('static', 'img/icons/small/msg-reply.png') }}" alt="{% trans %}Reply{% endtrans %}" />{#
+                  #}</a>
                 {%- endif -%}
                 {%- if entry.message.recipients|length > 1 %}
-                  <a href="{{ entry|url('reply_to_all') }}" title="{% trans %}Reply to all{% endtrans %}">
-                    <img src="{{ href('static', 'img/icons/small/msg-reply-all.png') }}" alt="{% trans %}Reply to all{% endtrans %}" />
-                  </a>
+                  <a href="{{ entry|url('reply_to_all') }}" title="{% trans %}Reply to all{% endtrans %}">{#
+                    #}<img src="{{ href('static', 'img/icons/small/msg-reply-all.png') }}" alt="{% trans %}Reply to all{% endtrans %}" />{#
+                  #}</a>
                 {%- endif -%}
               {%- endif %}
-              <a href="{{ entry|url('forward') }}" title="{% trans %}Forward{% endtrans %}">
-                <img src="{{ href('static', 'img/icons/small/msg-forward.png') }}" alt="{% trans %}Forward{% endtrans %}" />
-              </a>
+              <a href="{{ entry|url('forward') }}" title="{% trans %}Forward{% endtrans %}">{#
+                #}<img src="{{ href('static', 'img/icons/small/msg-forward.png') }}" alt="{% trans %}Forward{% endtrans %}" />{#
+              #}</a>
               {%- if not entry.in_archive %}
-                <a href="{{ entry|url }}?action=archive" title="{% trans %}Archive{% endtrans %}">
-                  <img src="{{ href('static', 'img/icons/small/archive.png') }}" alt="{% trans %}Archive{% endtrans %}" />
-                </a>
+                <a href="{{ entry|url }}?action=archive" title="{% trans %}Archive{% endtrans %}">{#
+                  #}<img src="{{ href('static', 'img/icons/small/archive.png') }}" alt="{% trans %}Archive{% endtrans %}" />{#
+                #}</a>
               {%- endif %}
             </td>
             <td class="pn_delete">

--- a/inyoka/portal/templates/portal/privmsg/index.m.html
+++ b/inyoka/portal/templates/portal/privmsg/index.m.html
@@ -12,26 +12,26 @@
 
 {% block content %}
   {%- if not folder %}
-    <a href="{{ href('portal', 'privmsg', 'inbox') }}"{{ selected == 'inbox' and ' class="active"' or '' }}>
-      <div class="button">{% trans %}Inbox{% endtrans %}</div>
-    </a>
-    <a href="{{ href('portal', 'privmsg', 'sent') }}"{{ selected == 'sent' and ' class="active"' or '' }}>
-      <div class="button">{% trans %}Sent mail{% endtrans %}</div>
-    </a>
-    <a href="{{ href('portal', 'privmsg', 'archive') }}"{{ selected == 'archive' and ' class="active"' or '' }}>
-      <div class="button">{% trans %}Archive{% endtrans %}</div>
-    </a>
-    <a href="{{ href('portal', 'privmsg', 'trash') }}"{{ selected == 'trash' and ' class="active"' or '' }}>
-      <div class="button">{% trans %}Trash{% endtrans %}</div>
-    </a>
-    <a href="{{ href('portal', 'privmsg', 'new') }}"{{ selected == 'new' and ' class="active"' or '' }}>
-      <div class="button">{% trans %}Compose message{% endtrans %}</div>
-    </a>
+    <a href="{{ href('portal', 'privmsg', 'inbox') }}"{{ selected == 'inbox' and ' class="active"' or '' }}>{#
+      #}<div class="button">{% trans %}Inbox{% endtrans %}</div>{#
+    #}</a>
+    <a href="{{ href('portal', 'privmsg', 'sent') }}"{{ selected == 'sent' and ' class="active"' or '' }}>{#
+      #}<div class="button">{% trans %}Sent mail{% endtrans %}</div>{#
+    #}</a>
+    <a href="{{ href('portal', 'privmsg', 'archive') }}"{{ selected == 'archive' and ' class="active"' or '' }}>{#
+      #}<div class="button">{% trans %}Archive{% endtrans %}</div>{#
+    #}</a>
+    <a href="{{ href('portal', 'privmsg', 'trash') }}"{{ selected == 'trash' and ' class="active"' or '' }}>{#
+      #}<div class="button">{% trans %}Trash{% endtrans %}</div>{#
+    #}</a>
+    <a href="{{ href('portal', 'privmsg', 'new') }}"{{ selected == 'new' and ' class="active"' or '' }}>{#
+      #}<div class="button">{% trans %}Compose message{% endtrans %}</div>{#
+    #}</a>
   {%- else %}
     {%- if message %}
-      <a href="{{ href('portal', 'privmsg', folder.id ) }}">
-        <div class="button">{% trans %}« Back{% endtrans %}</div>
-      </a>
+      <a href="{{ href('portal', 'privmsg', folder.id ) }}">{#
+        #}<div class="button">{% trans %}« Back{% endtrans %}</div>{#
+      #}</a>
       <h3>{% trans name=message.author|e %}Message from {{ name }}{% endtrans %}</h3>
       <div class="meta">
         {{ message.pub_date|datetimeformat }} |
@@ -57,17 +57,17 @@
         <a href="?action=delete"><span>{% trans %}Delete{% endtrans %}</span></a>
       </section>
     {%- else %}
-      <a href="{{ href('portal', 'privmsg') }}">
-        <div class="button">{% trans %}« Messages{% endtrans %}</div>
-      </a>
+      <a href="{{ href('portal', 'privmsg') }}">{#
+        #}<div class="button">{% trans %}« Messages{% endtrans %}</div>{#
+      #}</a>
       {% for entry in entries %}
-        <a href="{{ entry|url }}">
-          <div class="button{{ ' unread' if not entry.read }}">
+        <a href="{{ entry|url }}">{#
+          #}<div class="button{{ ' unread' if not entry.read }}">
             {%- trans subject=entry.message.subject|e, author=entry.message.author|e -%}
               {{ subject }} from {{ author }}
             {%- endtrans -%}
-          </div>
-        </a>
+          </div>{#
+        #}</a>
       {% endfor %}
     {%- endif %}
   {%- endif %}

--- a/inyoka/portal/templates/portal/search.html
+++ b/inyoka/portal/templates/portal/search.html
@@ -104,7 +104,7 @@
         <p class="meta">
           zuletzt bearbeitet von
           <a href="{{ href('portal', 'user', wiki_result.last_rev.user|e) }}">
-            {{ wiki_result.last_rev.user|e }}
+            {{- wiki_result.last_rev.user|e -}}
           </a>
           {{ wiki_result.last_rev.change_date|specificdatetimeformat }}
         </p>
@@ -116,7 +116,7 @@
         <img src="{{ href('static', 'img/icons/small/%s.png' % doc.component|lower) }}"
           alt="{{ doc.component }}" title="{{ doc.component }}" />
         <a href="{{ doc.url }}{% if doc.highlight and highlight %}?highlight={{ highlight|urlencode|e }}{% endif %}">
-          {{ doc.title }}
+          {{- doc.title -}}
         </a>
         {%- if doc.solved %}
         <img src="{{ href('static', 'img/check.png') }}" alt="Gelöst" title="Gelöst" />

--- a/inyoka/portal/templates/portal/user_overview.html
+++ b/inyoka/portal/templates/portal/user_overview.html
@@ -15,9 +15,9 @@
 
 {% macro user_edit_button(link, icon, name) %}
   <li>
-    <span><a href="{{ link }}">
-      <img src="{{ href('static', 'img/portal/user_%s.png'|format(icon)) }}" alt="{{ name }}" /><br />
-      {{ name }}
+    <span><a href="{{ link }}">{#
+      #}<img src="{{ href('static', 'img/portal/user_%s.png'|format(icon)) }}" alt="{{ name }}" /><br />
+      {{- name -}}
     </a></span>
   </li>
 {% endmacro %}

--- a/inyoka/portal/templates/portal/usercp/change_password.html
+++ b/inyoka/portal/templates/portal/usercp/change_password.html
@@ -26,11 +26,11 @@
         <code id="random_password">{{ random_pw }}</code> |
       {%- endif %}
       <a href="{{ href('portal', 'usercp', 'password', random='true') }}" id="random_password_link">
-        {%- if random_pw %}
+        {%- if random_pw -%}
           {% trans %}Generate a new one{% endtrans %}
-        {%- else %}
+        {%- else -%}
           {% trans %}Generate a random password{% endtrans %}
-        {%- endif %}
+        {%- endif -%}
       </a>
     </p>
     <p>

--- a/inyoka/portal/templates/portal/usercp/index.html
+++ b/inyoka/portal/templates/portal/usercp/index.html
@@ -12,9 +12,9 @@
 
 {% macro usercp_button(link, icon, name) %}
   <li>
-    <span><a href="{{ link }}">
-      <img src="{{ href('static', 'img/usercp/usercp-%s.png'|format(icon)) }}" alt="{{ name }}" /><br />
-      {{ name }}
+    <span><a href="{{ link }}">{#
+      #}<img src="{{ href('static', 'img/usercp/usercp-%s.png'|format(icon)) }}" alt="{{ name }}" /><br />
+      {{- name -}}
     </a></span>
   </li>
 {% endmacro %}

--- a/inyoka/portal/templates/portal/usercp/subscriptions.html
+++ b/inyoka/portal/templates/portal/usercp/subscriptions.html
@@ -52,9 +52,9 @@
                 {{ object._meta.verbose_name }}: <a href="{{ object|url }}">{{ object|e }}</a>
                 {%- if type == 'topic' -%}
                   {%- if not object.get_read_status(USER) %}
-                    <a href="{{ object|url('first_unread') }}" title="{% trans %}Show unread posts{% endtrans %}">
-                      <img src="{{ href('static', 'img/forum/goto.png') }}" alt="{% trans %}Show unread posts{% endtrans %}" />
-                    </a>
+                    <a href="{{ object|url('first_unread') }}" title="{% trans %}Show unread posts{% endtrans %}">{#
+                      #}<img src="{{ href('static', 'img/forum/goto.png') }}" alt="{% trans %}Show unread posts{% endtrans %}" />{#
+                    #}</a>
                   {%- endif %}
                   {%- if object.paginated %} &#160; &#160; [{{ object.get_pagination() }}]{% endif -%}
                 {%- endif %}

--- a/inyoka/templates/macros.html
+++ b/inyoka/templates/macros.html
@@ -43,8 +43,8 @@
 
 {# render a list entry of the mod nav #}
 {% macro render_modnavi_li(label, href, icon, count=False) %}
-  <a href="{{ href|e }}"{% if count %} class="highlight"{% endif %}>
-    <img src={{ icon|e }} alt="{{ label }}" title="{{ label }} ({{ count }})" />
-    <span class="description">{{ count }}</span>
-  </a>
+  <a href="{{ href|e }}"{% if count %} class="highlight"{% endif %}>{#
+    #}<img src={{ icon|e }} alt="{{ label }}" title="{{ label }} ({{ count }})" />{#
+    #}<span class="description">{{ count }}</span>{#
+  #}</a>
 {% endmacro %}

--- a/inyoka/templates/overall.html
+++ b/inyoka/templates/overall.html
@@ -116,36 +116,36 @@
             {%- if USER.is_authenticated %}
               <li>
                 <a href="{{ href('portal', 'logout', next=CURRENT_URL) }}">
-                  {% trans user=USER.username|e %}Logout [{{ user }}]{% endtrans %}
+                  {%- trans user=USER.username|e %}Logout [{{ user }}]{% endtrans -%}
                 </a>
               </li>
               <li>
                 <a href="{{ href('portal', 'usercp') }}">
-                  {% trans %}Control panel{% endtrans %}
+                  {%- trans %}Control panel{% endtrans -%}
                 </a>
               </li>
               <li>
                 {%- if pm_count -%}
                   <strong>
                     <a href="{{ href('portal', 'privmsg')}}">
-                      {% trans count=pm_count %}Private messages ({{ count }}){% endtrans %}
+                      {%- trans count=pm_count %}Private messages ({{ count }}){% endtrans -%}
                     </a>
                   </strong>
                 {%- else -%}
                   <a href="{{ href('portal', 'privmsg') }}">
-                    {% trans %}Private messages{% endtrans %}
+                    {%- trans %}Private messages{% endtrans -%}
                   </a>
                 {%- endif -%}
               </li>
             {%- else %}
               <li>
                 <a href="{{ href('portal', 'login', next=CURRENT_URL) }}" id="login_link">
-                  {% trans %}Login{% endtrans %}
+                  {%- trans %}Login{% endtrans -%}
                 </a>
               </li>
               <li>
                 <a href="{{ href('portal', 'register') }}">
-                  {% trans %}Register{% endtrans %}
+                  {%- trans %}Register{% endtrans -%}
                 </a>
               </li>
             {%- endif %}
@@ -154,12 +154,12 @@
         {%- if USER.can('manage_topics') or USER.can('article_edit') or USER.can('event_edit') %}
           <div id="admin_menu">
             <div class="bar">
-              <a id="admin_layer_button">
-                <img src="{{ href('static', 'img/admin/switch.png') }}"
-                     alt="{% trans %}Admin{% endtrans %}"
-                     title="{% trans %}Turn admin links on/off{% endtrans %}" />
-                <span class="description"></span>
-              </a>
+              <a id="admin_layer_button">{#
+                #}<img src="{{ href('static', 'img/admin/switch.png') }}"
+                       alt="{% trans %}Admin{% endtrans %}"
+                       title="{% trans %}Turn admin links on/off{% endtrans %}" />{#
+                #}<span class="description"></span>{#
+              #}</a>
             </div>
             <div class="bar">
               {%- if USER.can('manage_topics') %}

--- a/inyoka/templates/overall.m.html
+++ b/inyoka/templates/overall.m.html
@@ -62,11 +62,11 @@
             <li>
               {%- if USER.is_authenticated %}
                 <a href="{{ href('portal', 'logout', next=CURRENT_URL) }}">
-                  {% trans %}Logout{% endtrans %}
+                  {%- trans %}Logout{% endtrans -%}
                 </a>
               {%- else %}
                 <a href="{{ href('portal', 'login', next=CURRENT_URL) }}">
-                  {% trans %}Login{% endtrans %}
+                  {%- trans %}Login{% endtrans -%}
                 </a>
               {%- endif %}
             </li>
@@ -80,7 +80,7 @@
       <footer>
         <p>
           <a href="?flavour=full" class="flavour_switch" >
-            {% trans %}To classic version{% endtrans %}
+            {%- trans %}To classic version{% endtrans -%}
           </a>
         </p>
         2004 – 2012 ubuntuusers.de • Einige Rechte vorbehalten<br />

--- a/inyoka/wiki/templates/wiki/action_log.html
+++ b/inyoka/wiki/templates/wiki/action_log.html
@@ -57,11 +57,11 @@
             </td>
             <td class="author">
               {%- if revision.user %}
-                <a href="{{ revision.user|url|e }}">
-                  <img src="{{ revision.user.avatar_url|e }}" width="16" height="16"
-                       alt="{{ revision.user.username|e }}" />
-                  <span class="username">{{ revision.user.username|e }}</span>
-                </a>
+                <a href="{{ revision.user|url|e }}">{#
+                  #}<img src="{{ revision.user.avatar_url|e }}" width="16" height="16"
+                         alt="{{ revision.user.username|e }}" />{#
+                  #}<span class="username">{{ revision.user.username|e }}</span>
+                #}</a>
               {% else %}
                 {{ revision.remote_addr|e }}
               {% endif %}


### PR DESCRIPTION
There are various places where we have underlines within links that look ugly. E.g. the private messages list.
