### PR TITLE
Make the subscription filter work again. Fixes #716.

### DIFF
--- a/inyoka/portal/filters.py
+++ b/inyoka/portal/filters.py
@@ -57,7 +57,7 @@ class LinkWidget(BaseLinkWidget):
 
 
 class SubscriptionFilter(FilterSet):
-    content_type = ChoiceFilter(name='content_type__name', label='',
+    content_type = ChoiceFilter(name='content_type__model', label='',
         choices=(('', ugettext_lazy(u'All types')),) + tuple(SUPPORTED_SUBSCRIPTION_TYPES.iteritems()),
         widget=LinkWidget)
 


### PR DESCRIPTION
We should think about adding an more concrete filtering to the `SubscriptionFilter`: not only on `ContentType.model` but on `ContentType.app_label`, too. This would make the filtering more specific and reliable.
