### PR TITLE
Correctly render the ``Bild()`` macro during first save of a post.

### DIFF
--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -725,12 +725,14 @@ class Post(models.Model, LockableObject):
         .. note::
 
             This method saves the current state of the post and it's
-            revisions.  You do not have to do that yourself.
+            revisions. You do not have to do that yourself.
         """
         if self.text == text and self.is_plaintext == is_plaintext:
             return
 
-        if self.pk:
+        # We need to check for the empty text to prevent a initial empty
+        # revision
+        if self.pk and self.text.strip():
             # Create a first revision for the initial post
             if not self.has_revision:
                 PostRevision(post=self, store_date=self.pub_date,

--- a/inyoka/wiki/macros.py
+++ b/inyoka/wiki/macros.py
@@ -829,8 +829,9 @@ class Picture(Macro):
                     att_ids = map(int, filter(bool,
                         context.request.POST.get('attachments', '').split(',')
                     ))
-                    files = ForumAttachment.objects.filter(name=target, post=context.forum_post,
-                                                           id__in=att_ids)
+                    post = context.forum_post.id if context.forum_post else None
+                    files = ForumAttachment.objects.filter(name=target,
+                            post=post, id__in=att_ids)
                     return nodes.HTML(files[0].html_representation)
                 else:
                     file = ForumAttachment.objects.get(name=target, post=context.forum_post)


### PR DESCRIPTION
This is achieved by first saving the empty post, then updating the post ids for the attachments and finally save the post with the correct text which will render the images as expected.

http://forum.ubuntuusers.de/topic/bild-tags-werden-nicht-mehr-als-bilder-angezei/
