### PR TITLE
This commit fixes a problem in the post selection for topic split

### DIFF
--- a/inyoka/forum/services.py
+++ b/inyoka/forum/services.py
@@ -9,6 +9,8 @@
     :copyright: (c) 2007-2012 by the Inyoka Team, see AUTHORS for more details.
     :license: GNU GPL, see LICENSE for more details.
 """
+from urllib import unquote
+
 from django.db import transaction
 from django.utils.datastructures import MultiValueDictKeyError
 
@@ -153,6 +155,7 @@ def on_mark_topic_split_point(request):
     unchecked = False
 
     if topic and post_id:
+        topic = unquote(topic) # To replace quotes. e.g. the colon
         post_ids = post_ids if topic in post_ids else {topic: []}
 
         post_id_marked = '!%s' % post_id

--- a/inyoka/forum/tests/test_views.py
+++ b/inyoka/forum/tests/test_views.py
@@ -127,3 +127,29 @@ class TestViews(TestCase):
         self.assertEqual(len(self.client.get("/last24/5/").tmpl_context['topics']),
                          self.num_topics_on_last_page)
         self.assertTrue(self.client.get("/last24/6/").status_code == 404)
+
+    def test_service_splittopic(self):
+        t1 = Topic.objects.create(title='A: topic', slug='a:-topic',
+                author=self.user, forum=self.forum2)
+        p1 = Post.objects.create(text=u'Post 1', author=self.user,
+                topic=t1)
+
+        t2 = Topic.objects.create(title='Another topic', author=self.user,
+                forum=self.forum2)
+        p2 = Post.objects.create(text=u'Post 1', author=self.user,
+                topic=t2)
+
+        response = self.client.get('/', {
+                    '__service__': 'forum.mark_topic_split_point',
+                    'post': p1.pk,
+                    'topic': 'a%3A-topic'})
+        response = self.client.get('/topic/a%3A-topic/split/')
+        self.assertEqual(response.status_code, 200) # was 302 before
+
+        response = self.client.get('/', {
+                    '__service__': 'forum.mark_topic_split_point',
+                    'post': p2.pk,
+                    'topic': t2.slug})
+        response = self.client.get('/topic/%s/split/' % t2.slug)
+        self.assertEqual(response.status_code, 200)
+


### PR DESCRIPTION
If an old topic slug contains a character that normally is percent-encoded (e.g. a colon), the selection does not work. A request to `split/` page redirects back to the topic, because the transmitted slug does not match the real slug of the topic. URL unquoting solves that problem.
