### PR TITLE
Wiki construction fixes

### DIFF
--- a/inyoka/wiki/actions.py
+++ b/inyoka/wiki/actions.py
@@ -670,8 +670,8 @@ def do_mv_back(request, name):
                     return HttpResponseRedirect(url_for(page))
             ## Remove box
             text = page.revisions.latest().text.value
-            if text.startswith(u'[[Vorlage(Baustelle') or \
-                text.startswith(u'[[Vorlage(Überarbeitung'):
+            while text.startswith(u'[[Vorlage(Baustelle') or \
+                    text.startswith(u'[[Vorlage(Überarbeitung'):
                 text = text[text.find('\n')+1:]
             ## Rename
             if not _rename(request, page, new_name, new_text=text):


### PR DESCRIPTION
This PR fixes the problem with lost leading characters after renaming a wiki page from `Baustelle/NAME` to `NAME`. The Python function `lstrip()` treats its argument as an iterable and removes any leading character of that group (http://docs.python.org/library/stdtypes.html?highlight=str.lstrip#str.lstrip). But actually we just want to remove the first 9 letters plus the forward slash (totally 10 characters).

Another change is the handling of removing boxes indicating that a page is under construction or is a construction site. Besides removing just one box, Inyoka will remove ANY leading boxes matching these requirements.

Test will follow after merging https://github.com/inyokaproject/inyoka/pull/84 to prevent conflicts.
