### PR TITLE
Builddeps wiki class

### DIFF
--- a/inyoka/static/js/overall.js
+++ b/inyoka/static/js/overall.js
@@ -251,7 +251,7 @@ $(document).ready(function () {
   })();
 
   // add links to the "package" macro
-  $('.package-list, .package-list2').each(function (i, elm) {
+  $('.package-list, .builddeps').each(function (i, elm) {
     var tmp = $('.bash', elm);
     var apt = tmp[0];
     var aptitude = tmp[1];


### PR DESCRIPTION
builddeps cannot handle apt urls. hence introduce a package-list2 class to render those wiki templates without it.
