### PR TITLE
Update edit/revert/delete field descriptions. Closes #843 (trac)

### DIFF
--- a/inyoka/wiki/locale/de_DE/LC_MESSAGES/django.po
+++ b/inyoka/wiki/locale/de_DE/LC_MESSAGES/django.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Inyoka\n"
 "Report-Msgid-Bugs-To: http://trac.inyokaproject.org/\n"
-"POT-Creation-Date: 2012-12-27 11:58+0100\n"
+"POT-Creation-Date: 2013-01-08 18:37+0100\n"
 "PO-Revision-Date: 2012-11-03 13:01+0000\n"
 "Last-Translator: Markus Holtermann <inyoka@markusholtermann.eu>\n"
 "Language-Team: German (Germany) "
@@ -402,11 +402,9 @@ msgstr "Beschreibung"
 
 #: inyoka/wiki/templates/wiki/action_attach.html:35
 #: inyoka/wiki/templates/wiki/action_attach_edit.html:36
-#: inyoka/wiki/templates/wiki/action_delete.html:16
 #: inyoka/wiki/templates/wiki/action_edit.html:34
-#: inyoka/wiki/templates/wiki/action_revert.html:16
-msgid "Note:"
-msgstr "Notiz:"
+msgid "Edit summary:"
+msgstr "Änderungskommentar:"
 
 #: inyoka/wiki/templates/wiki/action_attach.html:40
 msgid "Overwrite existing attachments with same name:"
@@ -514,6 +512,11 @@ msgstr "Dieser Artikel ist verwaist und von keiner Seite referenziert."
 #: inyoka/wiki/templates/wiki/action_delete.html:15
 msgid "Are you sure you want to delete this page?"
 msgstr "Bist du sicher, dass du diese Seite löschen möchtest?"
+
+#: inyoka/wiki/templates/wiki/action_delete.html:16
+#: inyoka/wiki/templates/wiki/action_revert.html:16
+msgid "Reason:"
+msgstr "Begründung:"
 
 #: inyoka/wiki/templates/wiki/action_delete.html:18
 msgid "Delete"
@@ -905,4 +908,3 @@ msgstr "Abbestellen"
 #: inyoka/wiki/templates/wiki/page.html:66
 msgid "Subscribe"
 msgstr "Abonnieren"
-

--- a/inyoka/wiki/locale/django.pot
+++ b/inyoka/wiki/locale/django.pot
@@ -1,14 +1,14 @@
 # Translations template for PROJECT.
-# Copyright (C) 2012 ORGANIZATION
+# Copyright (C) 2013 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2012.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2013.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2012-12-27 11:58+0100\n"
+"POT-Creation-Date: 2013-01-08 18:37+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -372,10 +372,8 @@ msgstr ""
 
 #: inyoka/wiki/templates/wiki/action_attach.html:35
 #: inyoka/wiki/templates/wiki/action_attach_edit.html:36
-#: inyoka/wiki/templates/wiki/action_delete.html:16
 #: inyoka/wiki/templates/wiki/action_edit.html:34
-#: inyoka/wiki/templates/wiki/action_revert.html:16
-msgid "Note:"
+msgid "Edit summary:"
 msgstr ""
 
 #: inyoka/wiki/templates/wiki/action_attach.html:40
@@ -475,6 +473,11 @@ msgstr ""
 
 #: inyoka/wiki/templates/wiki/action_delete.html:15
 msgid "Are you sure you want to delete this page?"
+msgstr ""
+
+#: inyoka/wiki/templates/wiki/action_delete.html:16
+#: inyoka/wiki/templates/wiki/action_revert.html:16
+msgid "Reason:"
 msgstr ""
 
 #: inyoka/wiki/templates/wiki/action_delete.html:18

--- a/inyoka/wiki/templates/wiki/action_attach.html
+++ b/inyoka/wiki/templates/wiki/action_attach.html
@@ -32,7 +32,7 @@
         {{ form.filename }}</p>
       <p><label for="id_text">{% trans %}Description:{% endtrans %}</label><br style="clear: both" /></p>
         <p>{{ form.text }}</p>
-      <p><label for="id_note">{% trans %}Note:{% endtrans %}</label>
+      <p><label for="id_note">{% trans %}Edit summary:{% endtrans %}</label>
         {{ form.note }}</p>
       <p>
         {{ form.override }}

--- a/inyoka/wiki/templates/wiki/action_attach_edit.html
+++ b/inyoka/wiki/templates/wiki/action_attach_edit.html
@@ -33,7 +33,7 @@
       </p>
       <p>{{ form.text }}</p>
       <p>
-        <label for="id_note">{% trans %}Note:{% endtrans %}</label>
+        <label for="id_note">{% trans %}Edit summary:{% endtrans %}</label>
         <br />
         {{ form.note }}
       </p>

--- a/inyoka/wiki/templates/wiki/action_delete.html
+++ b/inyoka/wiki/templates/wiki/action_delete.html
@@ -13,7 +13,7 @@
 <form action="{{ href('wiki', page.name, action='delete')|e }}" method="post">
   {{ csrf_token() }}
   <p>{% trans %}Are you sure you want to delete this page?{% endtrans %}</p>
-  <p>{% trans %}Note:{% endtrans %}</p>
+  <p>{% trans %}Reason:{% endtrans %}</p>
   <p><input type="text" name="note" size="30" />
      <input type="submit" value="{% trans %}Delete{% endtrans %}" />{#
    #}<input type="submit" name="cancel" value="{% trans %}Cancel{% endtrans %}" /></p>

--- a/inyoka/wiki/templates/wiki/action_edit.html
+++ b/inyoka/wiki/templates/wiki/action_edit.html
@@ -31,7 +31,7 @@
       <div class="license_note">{{ storage['license_note_rendered'] }}</div>
     {%- endif %}
     <div class="actions">
-      {% trans %}Note:{% endtrans %} {{ form.note }}
+      {% trans %}Edit summary:{% endtrans %} {{ form.note }}
       <input type="hidden" name="edit_time" value="{{ edit_time }}" />
       <input type="hidden" name="rev" value="{{ rev }}" />
       <input type="submit" name="preview" value="{% trans %}Preview{% endtrans %}" />

--- a/inyoka/wiki/templates/wiki/action_revert.html
+++ b/inyoka/wiki/templates/wiki/action_revert.html
@@ -13,7 +13,7 @@
 <form action="{{ href('wiki', page.name, rev=page.rev.id, action='revert')|e
       }}" method="post">
   {{ csrf_token() }}
-  <p>{% trans %}Note:{% endtrans %}</p>
+  <p>{% trans %}Reason:{% endtrans %}</p>
   <p><input type="text" name="note" size="30" />
      <input type="submit" value="{% trans %}Restore{% endtrans %}" />{#
    #}<input type="submit" name="cancel" value="{% trans %}Cancel{% endtrans %}" /></p>


### PR DESCRIPTION
Use more meaningful descriptions for edit/attachment/revert/delete fields.
