### PR TITLE
Hotfix: Require (un)subscribe_user to use POST requests.

### DIFF
--- a/inyoka/portal/templates/portal/profile.html
+++ b/inyoka/portal/templates/portal/profile.html
@@ -23,26 +23,38 @@
   {%- endif -%}
 {% endmacro %}
 
-{% macro generate_subscription_link(do='subscribe') %}
-  {{ href('portal', 'user', user.username, do)|e }}
-{% endmacro %}
-
 {% block portal_content %}
   <h3>{{ user.username|e }}
   {%- if request.user.can('user_edit') %}
     <a href="{{ href('portal', 'user', user.username, 'edit') }}" class="admin_link"><img
       src="{{ href('static', 'img/ikhaya/category_edit.png') }}" alt="{% trans %}Edit user{% endtrans %}" title="{% trans %}Edit user{% endtrans %}" /></a>
   {%- endif %}
+  </h3>
   {%- if request.user.can('subscribe_to_users') -%}
     {%- if is_subscribed %}
-      <a href="{{ generate_subscription_link(do='unsubscribe') }}" class="action action_subscribe subscribe_user admin link"><img
-      src="{{ href('static', 'img/forum/subscribe.png') }}" alt="{% trans %}Don’t watch anymore{% endtrans %}" title="{% trans %}Don’t watch anymore{% endtrans %}" /></a>
+      <form action="{{ href('portal', 'user', user.username, 'unsubscribe')|e }}"
+            method="post">
+        {{ csrf_token() }}
+        <input type="image"
+               class="action action_subscribe subscribe_user admin link"
+               src="{{ href('static', 'img/forum/subscribe.png') }}"
+               alt="{% trans %}Don’t watch anymore{% endtrans %}"
+               title="{% trans %}Don’t watch anymore{% endtrans %}" >
+        </input>
+      </form>
     {%- else %}
-      <a href="{{ generate_subscription_link() }}" class="action action_subscribe subscribe_user admin_link"><img
-      src="{{ href('static', 'img/forum/subscribe.png') }}" alt="{% trans %}Watch{% endtrans %}" title="{% trans %}Watch{% endtrans %}" /></a>
+      <form action="{{ href('portal', 'user', user.username, 'subscribe')|e }}"
+            method="post">
+          {{ csrf_token() }}
+        <input type="image"
+               class="action action_subscribe subscribe_user admin_link"
+               src="{{ href('static', 'img/forum/subscribe.png') }}"
+               alt="{% trans %}Watch{% endtrans %}"
+               title="{% trans %}Watch{% endtrans %}" >
+        </input>
+      </form>
     {%- endif -%}
   {%- endif %}
-  </h3>
   {%- if user in (User.objects.get_system_user(), User.objects.get_anonymous_user()) %}
     {% trans name=user.username|e %}{{ name }} is a system user.{% endtrans %}
   {%- elif user.is_deleted or user.is_banned %}

--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -32,6 +32,7 @@ from django.utils.html import escape
 from django.contrib import auth
 from django.contrib import messages
 from django.contrib.auth.views import password_reset, password_reset_confirm
+from django.views.decorators.http import require_POST
 
 from django_openid.consumer import Consumer, SessionPersist
 from django_mobile import get_flavour
@@ -529,6 +530,7 @@ def user_mail(request, username):
     }
 
 
+@require_POST
 @require_permission('subscribe_to_users')
 def subscribe_user(request, username):
     """Subscribe to a user to follow all of his activities."""
@@ -543,7 +545,7 @@ def subscribe_user(request, username):
               % {'username': user.username})
     return HttpResponseRedirect(url_for(user))
 
-
+@require_POST
 def unsubscribe_user(request, username):
     """Remove a user subscription."""
     user = User.objects.get(username)


### PR DESCRIPTION
Currently (un)subscribing from / to users is done via GET requests, which leads to the vulnerability to unintentionally (un)subscribe by CSRF attacks and therefore potentionally creating massive mails / getting no mails at all.

Tests will be created in my `tests` branch.
