### PR TITLE
Fix time parsing in planet_sync

### DIFF
--- a/inyoka/scripts/planet_sync.py
+++ b/inyoka/scripts/planet_sync.py
@@ -24,6 +24,7 @@ xml.sax.make_parser = lambda x: make_parser()
 # End XML patching.
 import re
 import sys
+import dateutil
 import feedparser
 from time import time
 from datetime import datetime
@@ -53,6 +54,12 @@ def debug(msg):
     """Helper function that prints to stderr if debugging is enabled."""
     if settings.DEBUG:
         sys.stderr.write(msg.encode('utf-8') + '\n')
+
+
+def dateutilDateHandler(aDateString):
+    return dateutil.parser.parse(aDateString).utctimetuple()
+
+feedparser.registerDateHandler(dateutilDateHandler)
 
 
 def sync():


### PR DESCRIPTION
While moving from Feedparser 5.1 to 5.1.3 the time detection changed in some ways. This is solved in the planet sync script by adding a custom dateutil date parser handler.

With Feedparser 5.1 a string `'Sun Jul 15 00:15:00 +0000 2012'` was correctly recognized as

``` python
time.struct_time(tm_year=2012, tm_mon=7, tm_mday=15,
                 tm_hour=0, tm_min=15, tm_sec=0,
                 tm_wday=6, tm_yday=197, tm_isdst=0)
```

. After the updated it is recognized as

``` python
time.struct_time(tm_year=2000, tm_mon=7, tm_mday=15,
                 tm_hour=0, tm_min=0, tm_sec=0,
                 tm_wday=5, tm_yday=197, tm_isdst=0)
```

which is, obviously, not what we want.

Using `dateutil.parser.parse().utctimetuple()` we are again able to get the right tuple. This also works for non UTC start time string:

``` python
dateutil.parser.parse('Sun Jul 15 00:15:00 +0200 2012').utctimetuple()
time.struct_time(tm_year=2012, tm_mon=7, tm_mday=14,
                 tm_hour=22, tm_min=15, tm_sec=0,
                 tm_wday=5, tm_yday=196, tm_isdst=0)
```
