### PR TITLE
Fixes the following bugs from #857

### DIFF
--- a/inyoka/portal/templates/portal/calendar_detail.html
+++ b/inyoka/portal/templates/portal/calendar_detail.html
@@ -26,18 +26,25 @@
 </h3>
 <table class="vevent admin_link_hover">
   <tr><th>{% trans %}Date{% endtrans %}</th><td>
-    {{ _('from') }} {{ event.date|naturalday }}
-    {% if event.time %}
-      {{ event.startdatetime|time }}
-    {% endif %}
-    {%- if event.enddate or event.endtime %}
-      {{ _('to') }}
-      {% if event.enddate %}
-        {{ event.enddate|naturalday }}
+    {%- if event.date != None %}
+      {{ _('from') }}
+      {% if event.time == None %}
+        {{ event.date|naturalday }}
+      {% else %}
+        {{ event.startdatetime|naturalday }}
+        {{ event.startdatetime|time }}
       {% endif %}
-      {% if event.endtime %}
-        {{ event.enddatetime|time }}
+      {%- if event.enddate != None %}
+        {{ _('to') }}
+        {% if event.time == None %}
+          {{ event.enddate|naturalday }}
+        {% else %}
+          {{ event.enddatetime|naturalday }}
+          {{ event.enddatetime|time }}
+        {% endif %}
       {% endif %}
+    {% else %}
+      –
     {% endif %}
   </td></tr>
   {%- if event.location_town %}


### PR DESCRIPTION
http://trac.inyokaproject.org/ticket/857
- if start time or end time is 00:00 the date is one day off (ticket #857)
- if the start time or end time is 0:00 no time is shown in England in winter (due to UTC+0 and query for != 0)
- if the start time or end time is 2:00 no time is shown (due to UTC+2 in Germany, same as above)
