### PR TITLE
Fixes #596 -- avoid pagination in static file index

### DIFF
--- a/inyoka/portal/templates/portal/overall.html
+++ b/inyoka/portal/templates/portal/overall.html
@@ -80,7 +80,8 @@
       <li><a href="{{ href('portal', 'pages') }}">{% trans %}Static pages{% endtrans %}</a></li>
     {% endif %}
     {%- if USER.can('static_file_edit') %}
-      <li><a href="{{ href('portal', 'files') }}">{% trans %}Static files{% endtrans %}</a></li>
+      {# hard code a huge numbers of entries per page to avoid any pagination. :TODO: Find more elegant solution #}
+      <li><a href="{{ href('portal', 'files', paginate_by=42000) }}">{% trans %}Static files{% endtrans %}</a></li>
     {% endif %}
     </ul>
     {%- endif %}


### PR DESCRIPTION
Just change the link in the portal sidebar instead of "really" avoiding pagination. Not the most elegant solution, but this is acceptable for the Ikhaya team (at least according to the Ikhaya team leader).
