### PR TITLE
Rewrite of the installation guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,9 @@ master_doc = 'index'
 project = u'Inyoka'
 copyright = u'2007 - %d by the Inyoka Team, see AUTHORS for more details' % datetime.date.today().year
 
+# Show todo notes
+todo_include_todos = True
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,195 @@
+.. _getting-started:
+
+===============
+Getting Started
+===============
+
+Aussuming you already have :ref:`installed <installation>` Inyoka,
+you can start coding/translating/documentating etc.
+
+Working with Git
+================
+
+Branches
+********
+
+You can check your branches via
+
+.. code-block:: console
+
+  (inyoka)$ git branch
+
+The current active branch will have an asterisk at the beginning of the line.
+Before starting a development in a branch you should get the newest version:
+
+.. code-block:: console
+
+  (inyoka)$ git pull upstream staging
+
+Adding a new branch for your development:
+
+.. code-block:: console
+
+  (inyoka)$ git checkout -b fix/ticket861
+  Switched to a new branch 'fix/ticket861'
+  (inyoka)$ git branch
+  * fix/ticket861
+    staging
+
+The ticket name can be derived from the `error tracker <http://trac.inyokaproject.org/>`_.
+
+You can switch to another branch via
+
+.. code-block:: console
+
+  (inyoka)$ git checkout staging
+  Switched to branch 'staging'
+  (inyoka)$ git checkout fix/ticket861
+  Switched to branch 'fix/ticket861'
+
+Note: Only change files if you are in the correct branch! You should not change files on *staging* directly.
+
+Comitting changes
+*****************
+
+After you have changed some files on your branch you can check your changes via
+
+.. code-block:: console
+
+  (inyoka)$ git status
+
+To mark your changes for the commit and to add new files you need to do:
+
+.. code-block:: console
+
+  (inyoka)$ git add "ALL YOUR CHANGED AND ADDED FILES"
+
+Check again with ``git status`` and then commit your change via
+
+.. code-block:: console
+
+  (inyoka)$ git commit -m "Fixes #861 -- Short description"
+
+This will commit your changes to your local repository only.
+
+Next you need to push the changes to your origin repository (your forked Inyoka project):
+
+.. code-block:: console
+
+  (inyoka)$ git push -u origin BRANCHNAME
+  
+Add pull request
+****************
+
+Visit the `GitHub website <https://github.com/>`_ and login. Then visit
+you forked Inyoka project (mostly on
+`https://github.com/$GITNAME/inyoka`_).
+
+You should see a green button for adding the pull request from your
+branch to *inyokaproject/staging*. Just do it and hope that it will
+be pulled by a developer to the original Inyoka.
+
+You do not need to add a comment in Trac, as this is automatically done.
+Just remember to start your commit message with "Fixes #number".
+
+Getting latest version on developement branch
+*********************************************
+
+.. todo::
+   Shouldn't this be done *before* comitting so merging the PR is easier?
+
+If you have developed for a while the Inyoka project files may have changed by other developers. So you need to synchronize:
+
+.. code-block:: console
+
+  (inyoka)$ git checkout staging
+  (inyoka)$ git pull upstream staging
+
+This will get the lates version on your staging branch. Then you need to push the changes on the staging branch to your origin:
+
+.. code-block:: console
+
+  (inyoka)$ git push origin staging
+
+And last you can merge the changes on staging to your developement branch:
+
+.. code-block:: console
+
+  (inyoka)$ git checkout BRANCHNAME
+  (inyoka)$ git merge staging
+
+
+Testing
+=======
+
+Run tests
+*********
+
+Before adding a pull request or before committing at all you should run
+all unit tests so that you see that you don't have broken anything:
+
+.. code-block:: console
+
+  (inyoka)$ ./tests/runtests.sh --settings tests.settings.sqlite
+
+You can just run some specific tests:
+
+.. code-block:: console
+
+  (inyoka)$ ./tests/runtests.sh --settings tests.settings.sqlite
+  tests.apps.ikhaya.test_forms
+
+where ``tests.apps.ikhaya.test_forms`` is the directory structure
+``ests/apps/ikhaya/test_forms``.
+
+Add tests
+*********
+
+If  you changed or added some Python files you should add some unit tests
+as well for the classes. You'll find the tests under
+``tests/apps/$APPNAME/``.
+
+The  Python test files start with ``test_*`` For adding new tests you can
+mostly open a file and copying other test classes or test methods.
+
+
+Translate Inyoka
+================
+
+.. todo::
+   Put more information here.
+
+Every component of Inyoka has its own translation file. 
+You can switch languages by changing the ``LANGUAGE_CODE`` variable in ``development_settings.py``
+
+.. code-block:: console
+
+    LANGUAGE_CODE = 'en'
+
+Template syntax:
+
+.. code-block:: console
+
+    {% trans %}ENGLISH TEXT{% endtrans %}
+
+After changing code, extract strings from source code, updating ``*.po`` and ``*.pot`` files:
+
+.. code-block:: console
+
+  (inyoka) $ python manage.py makemessages
+
+Change the translations in ``*.po`` files (e. g. ``inyoka/wiki/locale/de_DE/LC_MESSAGES/django.po``)
+Compile the correspondingi ``*.mo`` files
+
+.. code-block:: console
+
+  (inyoka)$ python manage.py compilemessages
+
+Restart server to test.
+
+
+Test someone's Pull Request
+===========================
+
+.. todo::
+   Fill me.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,16 +14,9 @@ Overview
     :maxdepth: 2
 
     installation
+    getting_started
     inyoka
     settings
-
-Releases
-========
-
-.. toctree::
-    :maxdepth: 2
-
-    releases/index
 
 
 Indices and tables

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,86 +4,309 @@
 Installation
 ============
 
-Requirements
+Idea
+====
+
+Inyoka is developed via `GitHub
+<https://github.com/inyokaproject/inyoka>`_.  Note: You need the correct
+access rights to see the GitHub repository!  Documentation for git:
+`<http://git-scm.com/>`_
+
+The idea for developing Inyoka is to fork the main project, do your
+changes in your own repository and then add a “Pull Rquest” for the
+original Inyoka. A developer should then comment your changes or will
+directly merge it.
+
+Note: The changes in Inyoka will not immediately be visible on
+`ubuntuusers.de <http://ubuntuusers.de/>`_
+
+
+Preparation
+===========
+
+Git access
+**********
+
+If you do not have a login on `GitHub <https://github.com/>`_ get one so
+that you can fork Inyoka and improve it.
+
+If you do not have Git installed install it:
+
+.. code-block:: console
+
+  $ sudo apt-get install git
+
+Creating SSH key
+****************
+
+If you do not have a SSH key, create one:
+
+.. code-block:: console
+
+  $ ssh-keygen -t rsa -b 4096
+
+Then you need to add your *public* key to your profile in Git under
+*"Account Profile -> SSH keys -> Add SSH key"*:
+
+.. code-block:: console
+
+  $ cat .ssh/id_rsa.pub
+
+Getting access to the Inyoka repository
+***************************************
+
+Then you need to write to `a developer <https://github.com/Markush2010>`_
+so that you get the correct access rights to fork the project.  Simply
+klick the "Fork" Button on `<https://github.com/inyokaproject/inyoka>`_ to
+create a new *private* Fork of this Repository.
+
+
+Installation
 ============
 
-The Inyoka installation requires at least `Python 2.7 <http://python.org>`_
-including their development header files. Since Inyoka should run in its own
-virtual environment, you need the `Python setuptools
-<http://pypi.python.org/pypi/setuptools>`_. The database in the back-end can be
-any that is officially supported by :ref:`Django
-<django:database-installation>`.
+First setup
+***********
 
-The code is mostly tested with MySQL but should work with PostgreSQL, SQLite or
-any other database Django supports.
-
-Additionally `Jinja 2.5 <http://jinja.pocoo.org/>`_ or higher is required as
-well as `Xapian <http://xapian.org/>`_ for the full text search facilities.
-For the planet application the `feedparser library
-<http://code.google.com/p/feedparser/>`_ must be installed. Additionally
-chardet is recommended so that it can better guess broken encodings of feeds.
-For the pastebin, wiki and some other parts `Pygments 1.4
-<http://pygments.org/>`_ or higher must be available. MySQL must support InnoDB
-or any other transaction engine like falcon (untested though). For incoming
-HTML data that is converted to XHTML we also need html5lib. To let the inyoka
-services run (required) you need also `simplejson
-<http://simplejson.readthedocs.org/en/latest/index.html>`_.
-
-We're using the recent stable `Django <https://www.djangoproject.com/>`_
-releases.
-
-For deployment memcached is the preferred caching system. Otherwise use many
-threads and few processes and enable `locmem`.
-
-Building virtual environment
-============================
-
-Assuming the Inyoka project files are located so that
-``~/inyoka/inyoka/__init__.py`` holds, you should create a directory
-``~/venv/``. Then go the directory ``~/inyoka/`` and run
-following commands:
+Before  you start you need to get a local copy of your forked Inyoka
+project. So open a terminal and move to a directory where you want the
+Inyoka files to be stored. Then you can clone the repository:
 
 .. code-block:: console
 
-   $ mkdir ../venv
-   $ python2 extra/make-bootstrap.py > bootstrap.py
-   $ python2 bootstrap.py ../venv/
-   $ . ../venv/bin/activate
-   $ pip install -r extra/requirements/production.txt
+  $ git clone git@github.com:$GITNAME/inyoka.git
 
-This will take some time, depending on your network connection and CPU and
-memory. Depending on your environment you need to install additional drivers
-for you database. In case of MySQL run:
+``$GITNAME``  is your login name on GitHub. This command will create a
+new directory  called *inyoka* in your current directory. So go to it:
 
 .. code-block:: console
 
-   $ pip install MySQL-python
+  $ cd inyoka
 
-Configuration
-=============
-
-In the meantime we can start to configure Inyoka. Copy the file
-``~/inyoka/example_development_settings.py`` to ``~/inyoka/settings.py`` and open
-the new file in your favourite editor. Configure your Inyoka installation
-according to your wishes. The :ref:`settings` documentation has detailed
-information to all configuration directives.
-
-Make sure that you have created the Inyoka database and the regarding user.
-Check that the Inyoka database user can ``CREATE`` and ``ALTER`` tables!
-
-Now we need to tell Django about the settings file. Remember to omit the file
-extension ``.py`` here.
+Next you need to add the upstream project for your fork and do some update
+afterwards so that you have the latest files:
 
 .. code-block:: console
 
-   $ export DJANGO_SETTINGS_MODULE="settings"
+  $ git remote add upstream git@github.com:inyokaproject/inyoka.git
+  $ git remote update
+  $ git pull upstream staging
 
-Setup
-=====
+Package installation
+********************
 
-The next step is the database initialization:
+For compiling Inyoka and its dependencies you need a lot of developer
+files:
 
 .. code-block:: console
 
-   $ python manage.py syncdb
-   $ python manage.py migrate
+  $  sudo apt-get install python-virtualenv libxml2-dev libxslt1-dev
+  libzmq-dev zlib1g-dev libjpeg-dev uuid-dev libfreetype6-dev
+  libmysqlclient-dev python-setuptools
+
+Further you need the Python 2.7 files:
+
+.. code-block:: console
+
+  $ sudo apt-get install python2.7
+  $ sudo apt-get install python2.7-dev    #(Precise)
+  $ sudo apt-get install libpython2.7-dev #(Trusty)
+
+Adding links (Ubuntu only)
+**************************
+
+Inyoka  needs the program '''virtualenv''' and expects the version 2.7. In
+Ubuntu the installed binary does not have the version tag in the name.  So
+you need to add a softlink:
+
+.. code-block:: console
+
+  $ cd /usr/bin/
+  $ sudo ln -s virtualenv virtualenv-2.7
+
+Actual instalallation
+*********************
+Next you can start the actual Inyoka installation:
+
+.. code-block:: console
+
+  $ ./extra/install.sh
+
+A lot of files will be downloaded and compiled. Further there will be
+some warnings that you can ignore. Hopefully there is not error and
+everything will compile fine.
+
+At the end you need to edit your *etc/hosts* with root privilegies
+and add the following line:
+
+.. code-block::
+
+  127.0.0.1       ubuntuusers.local forum.ubuntuusers.local
+      paste.ubuntuusers.local   wiki.ubuntuusers.local
+      planet.ubuntuusers.local  ikhaya.ubuntuusers.local
+      static.ubuntuusers.local  media.ubuntuusers.local
+
+This will route all ubuntuusers.local calls in your browser to your
+localhost.
+
+Note: This is only one line! Watch for linebreaks!
+
+
+Working with Inyoka the first time
+==================================
+
+Activate Inyoka environment
+***************************
+
+For working with Inyoka you need to activate the correct environment. It
+will change the PATH and the prompt a little bit:
+
+.. code-block:: console
+
+  $ source ~/.venvs/inyoka/bin/activate
+
+Note: You need to do this everytime you open a new terminal/shell and want
+to work with Inyoka! Do not forget!
+
+If the environment is active you'll see the entry *(inyoka)* at the
+start of your prompt.
+
+You can check if the environment is active:
+
+.. code-block:: console
+
+  (inyoka)$ echo $PATH
+
+The entry *home/$USER/.venvs/inyoka/bin* should appear at the
+beginning.
+
+Using MySQL
+***********
+
+Even if you can use other databases than MySQL it's mostly tested with it.
+So first install MySQL:
+
+.. code-block:: console
+
+  $ sudo apt-get install mysql-server
+
+You will be asked for a password (maybe several times). You can leave it
+empty if you want to.
+
+Then you can install the Python binding for MySQL:
+
+.. code-block:: console
+
+  (inyoka)$ pip install MySQL-python
+
+Then you need to change the developer settings for the database. Edit the
+file *development_settings.py*  in the *inyoka* directory. You can leave
+the database entries if you haven't set a password during installation of
+MySQL above. Otherwise  you need to add your password:
+
+.. code-block:: console
+
+  'NAME': 'ubuntuusers',
+  'USER': 'root',
+  'PASSWORD': '',
+
+Further you should change the line
+
+.. code-block:: console
+
+  SECRET_KEY = None
+
+to
+
+.. code-block:: console
+
+  SECRET_KEY = 'development-key'
+
+
+.. todo::
+  language settings
+
+Creating test database
+**********************
+
+For testing you need to add a database in MySQL:
+
+.. code-block:: console
+
+  $ mysql -u root [-p]
+  mysql> create database ubuntuusers;
+  mysql> quit
+
+You only need to use the ``-p`` if you have set a password in MySQL.
+
+Next you need to add a superuser so that you gain all rights in the
+development installation:
+
+.. code-block:: console
+  (inyoka)$ python manage.py syncdb@localhost
+  (inyoka)$  python manage.py migrate
+  (inyoka)$  python manage.py create_superuser
+  username: admin
+  email: admin@localhost
+  password: admin
+  repeat: admin
+  created superuser
+
+Of  course you can use another password, but you should keep the  *admin*
+as username because it will be used in some test files.
+
+Now you can create the real test data:
+
+.. code-block:: console
+
+  (inyoka)$ ./make_testdata.py
+
+.. todo::
+   How to receive notifications via jabber/email?
+
+Starting Inyoka
+***************
+Finally you can start the server the first time:
+
+.. code-block:: console
+
+  (inyoka)$ python manage.py runserver ubuntuusers.local:8080
+
+In your browser open the url `<http://ubuntuusers.local:8080/>`_. You can
+login with the user  *admin* and the given password above.
+
+Before developing you should give your user full rights to everything. So
+click on *Portal -> Groups"* and click on the button *"Edit"* at  the
+group "Registriert":
+`<http://ubuntuusers.local:8080/group/Registriert/edit/>`_
+
+Check all boxes except *Not in use anymore"*.  For accessing the forum
+select all random forums via *[Ctrl]* and set all rights to *"Yes"*.
+Commit the changes via the button *Send"*
+
+You may should stop the running server via *[Ctrl-C]* and start it
+again before the access rights are correct.
+
+
+Working with Inyoka everytime
+=============================
+
+Environment and Server
+**********************
+
+First open a terminal, set the environment and start the server:
+
+.. code-block:: console
+
+  $ source ~/.venvs/inyoka/bin/activate
+  (inyoka)$ python manage.py runserver ubuntuusers.local:8080
+
+Then open another terminal, set the environment. Here you can work
+normally via Git.
+
+
+And now?
+========
+
+Congratulations: You have installed a local instance of Inyoka.  It is
+time to start hacking, read :ref:`getting-started` to learn how to submit
+your first fix.

--- a/extra/requirements/test.txt
+++ b/extra/requirements/test.txt
@@ -3,3 +3,5 @@
 mock==1.0.1
 django-discover-runner==1.0
 coverage==3.6
+docutils==0.12
+Sphinx==1.2.2


### PR DESCRIPTION
As discussed in in the [internal ubuntuusers forum](http://forum.ubuntuusers.de/topic/inyoka-installationsdokumentation-fuer-alle/), we want a rewrite of the installation guide.

What did I do:
- I basically took [this text](https://ubuntuusers.titanpad.com/4) (password is mentioned in the linked thread above), changed the format from Inyoka to ReST and split it into two parts.
- I created some todos.
- I added Sphinx as a requirement, so it is automatically installed.

What did I not do:
- Any non trivial improvements of the text.
- There is a German translation tutorial, which has not been copied.
- I rarely touched the general documentation, ie. files there may still be outdated. The goal was to create an installation guide, not to make everything under _inyoka/docs_ perfect.

How to test this, eg. see the documentation?
- In your venv, install Sphinx (`pip install Sphinx`)
- Navigate to _inyoka/docs_, run `make html` and open _inyoka/docs/build/html/index.html_ in your favorite browser.

This does not affect anything productive, so I‘d suggest to accept this PR although the installation guide is not finished yet. That‘s the easiest way others can work there as well.
