### PR TITLE
The feed generator automatically adds the necessary <div> tag around the...

### DIFF
--- a/inyoka/planet/views.py
+++ b/inyoka/planet/views.py
@@ -122,14 +122,12 @@ def feed(request, mode='short', count=10):
     for entry in entries:
         kwargs = {}
         if mode == 'full':
-            kwargs['content'] = u'<div xmlns="http://www.w3.org/1999/' \
-                                u'xhtml">%s</div>' % entry.text
+            kwargs['content'] = entry.text
             kwargs['content_type'] = 'xhtml'
         if mode == 'short':
             summary = Truncator(entry.text).words(100, html=True)
-            kwargs['summary'] = u'<div xmlns="http://www.w3.org/1999/' \
-                                u'xhtml">%s</div>' % summary
-            kwargs['content_type'] = 'xhtml'
+            kwargs['summary'] = summary
+            kwargs['summary_type'] = 'xhtml'
         if entry.author_homepage:
             kwargs['author'] = {'name': entry.author,
                                 'uri': entry.author_homepage}


### PR DESCRIPTION
... content, if the content type is set to xhtml.

This gets rid of a redundant `<div xmlns="http://www.w3.org/1999/xhtml">`.
