### PR TITLE
Made forum.models.Topic.move() easier to understand.

### DIFF
--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -485,8 +485,8 @@ class Topic(models.Model):
                 last_post=new_post_query._clone().filter(forum__id__in=old_ids) \
                                                  .aggregate(count=Max('id'))['count'])
 
-        forum.invalidate_topic_cache()
-        self.forum.invalidate_topic_cache()
+        old_forum.invalidate_topic_cache()
+        new_forum.invalidate_topic_cache()
         self.reindex()
 
     def delete(self, *args, **kwargs):


### PR DESCRIPTION
When moving a topic the topic cache of the old and the new forum have to be invalidated. This is now done using the obvious names old_forum and new_forum.
