### PR TITLE
Fix #936 -- Server error when viewing event details

### DIFF
--- a/inyoka/portal/templates/portal/calendar_detail.html
+++ b/inyoka/portal/templates/portal/calendar_detail.html
@@ -36,7 +36,7 @@
       {% endif %}
       {%- if event.enddate != None %}
         {{ _('to') }}
-        {% if event.time == None %}
+        {% if event.endtime == None %}
           {{ event.enddate|naturalday }}
         {% else %}
           {{ event.enddatetime|naturalday }}


### PR DESCRIPTION
I'm ashamed this wasn't caught in testing. When trying to display the `endtime`, maybe we should test if an `endtime` is set instead of testing for a start time ...
