### PR TITLE
Umlaute and space are banned for new user names.

### DIFF
--- a/inyoka/utils/user.py
+++ b/inyoka/utils/user.py
@@ -16,7 +16,7 @@ import hashlib
 from django.conf import settings
 from django.contrib.auth import hashers
 
-_username_re = re.compile(ur'^[@\-\.a-z0-9 öäüß]{1,30}$', re.I | re.U)
+_username_re = re.compile(ur'^[@\-\.a-z0-9]{1,30}$', re.I | re.U)
 _username_url_re = re.compile(ur'^[@\-\._a-z0-9 öäüß]{1,30}$', re.I | re.U)
 _username_split_re = re.compile(ur'[\s_]+')
 


### PR DESCRIPTION
Per discussion on IRC new users should not be allowed anymore to use usernames with whitespace or Umlauts. This checks makes the checks for valid usernames more restrictive to only allow "A-Z", "a-z", "0-9" and "@" and ".".
