### PR TITLE
Mask post links totally and link posts in /reply

### DIFF
--- a/inyoka/forum/templates/forum/_edit_latestpost_row.html
+++ b/inyoka/forum/templates/forum/_edit_latestpost_row.html
@@ -12,8 +12,8 @@
   <tr id="post-{{ post.id }}">
     <td class="author">
       <p class="username"><a href="{{ post.author|url }}">{{ post.author|e }}</a></p>
-      <p>{% trans %}Posts:{% endtrans %} {{ post.author.post_count }}</p>
       <p>{% trans %}Member since:{% endtrans %} <br />{{ post.author.date_joined|naturalday }}</p>
+      <p class="posts">{% trans %}Posts:{% endtrans %} <a href="{{ href('forum', 'author', post.author.username) }}" rel="nofollow">{{ post.author.post_count }}</a></p>
     </td>
     <td class="post">
       <div class="postinfo">

--- a/inyoka/static/style/forum.less
+++ b/inyoka/static/style/forum.less
@@ -253,6 +253,7 @@ table.topic {
     p.posts {
       a {
         color: black;
+        text-decoration: none;
       }
     }
   }


### PR DESCRIPTION
As requested, I removed the underline from the post count link in posts and also added the link to the …/topic/reply page.

I thought about displaying the same text in …/topic/reply as in …/topic, but I like the idea to have a shorter version in the reply form. Therefore a general macro for these post rows does not make that much sense to me.
