### PR TITLE
links printed via print.css

### DIFF
--- a/inyoka/static/style/print.less
+++ b/inyoka/static/style/print.less
@@ -83,6 +83,18 @@ a {
     .text-wrap;
   }
 
+  /* urls that should NOT be printed:
+   *  o page-internal links
+   *  o link to user-profile
+   *  o images from cnd
+   */
+  &[href^="#"],
+  &[href*="/user/"],
+  &[href*="media.cdn.ubuntu-de.org"]
+  {
+    &:after { content: none;}
+  }
+
   &.headerlink, &.anchor {
     display: none;
   }
@@ -126,6 +138,10 @@ div.box, div.warning, div.notice {
   h3 {
     background-color: white;
     font-size: 110%;
+  }
+
+  a:after {
+    content: none;
   }
 }
 
@@ -195,15 +211,20 @@ tr.kopf {
 }
 
 /*
+ * Wiki
+ */
+
+/* hide first paragraph of package installation, because there are only
+   JS-buttons to switch between apt-get and aptitude */
+.package-list p:first-child {
+  display: none;
+}
+
+/*
  * Ikhaya
  */
 a.action, a.show_comments {
   display: none;
-}
-
-/* no hrefs after images that lie on the cdn */
-td > a[href*="media.cdn.ubuntu-de.org"]:after {
-  content: none;
 }
 
 /*


### PR DESCRIPTION
some urls were printed accidentally:
- page-internal links
- to user-profile
- after images (from cnd)
- links to switch between between apt-get/aptitude at a package-installation-list

see also http://forum.ubuntuusers.de/post/7047348/
