### PR TITLE
Allow Umlauts in Usernames again

### DIFF
--- a/inyoka/utils/user.py
+++ b/inyoka/utils/user.py
@@ -16,8 +16,8 @@ import hashlib
 from django.conf import settings
 from django.contrib.auth import hashers
 
-_username_re = re.compile(ur'^[@\-\.a-z0-9öäüß]{1,30}$', re.I | re.U)
-_username_url_re = re.compile(ur'^[@\-\._a-z0-9 öäüß]{1,30}$', re.I | re.U)
+_username_re = re.compile(ur'^[@\-\.a-z0-9äöüß]{1,30}$', re.I | re.U)
+_username_url_re = re.compile(ur'^[@\-\._a-z0-9 äöüß]{1,30}$', re.I | re.U)
 _username_split_re = re.compile(ur'[\s_]+')
 
 


### PR DESCRIPTION
Ubuntuusers Team choose to allow german Umlauts in Usernames.
