### PR TITLE
Remove legacy distributions

### DIFF
--- a/inyoka/forum/constants.py
+++ b/inyoka/forum/constants.py
@@ -22,29 +22,16 @@ POSTS_PER_PAGE = 15
 TOPICS_PER_PAGE = 30
 CACHE_PAGES_COUNT = 5
 
-UBUNTU_DISTROS_LEGACY = {
+UBUNTU_DISTROS = {
     'none': ugettext_lazy(u'Not specified'),
     'edubuntu': ugettext_lazy('Edubuntu'),
     'kubuntu': ugettext_lazy('Kubuntu'),
-    'kubuntu-kde4': ugettext_lazy(u'Kubuntu (KDE 4)'),
     'server': ugettext_lazy('Server'),
     'ubuntu': ugettext_lazy('Ubuntu'),
     'xubuntu': ugettext_lazy('Xubuntu'),
     'lubuntu': ugettext_lazy('Lubuntu'),
-    'unity': 'Unity',
+    'gnome': ugettext_lazy('Ubuntu GNOME'),
 }
-
-UBUNTU_DISTROS = [
-    ('none', ugettext_lazy(u'Not specified')),
-    ('edubuntu', ugettext_lazy('Edubuntu')),
-    ('kubuntu', ugettext_lazy('Kubuntu')),
-    ('server', ugettext_lazy('Server')),
-    ('ubuntu', ugettext_lazy('Ubuntu')),
-    ('xubuntu', ugettext_lazy('Xubuntu')),
-    ('lubuntu', ugettext_lazy('Lubuntu')),
-    ('unity', ugettext_lazy('Unity')),
-]
-
 
 def get_simple_version_choices():
     return [(v.number, str(v)) for v in get_ubuntu_versions() if v.is_active()]
@@ -55,4 +42,4 @@ def get_version_choices():
 
 
 def get_distro_choices():
-    return [('', ugettext_lazy('Distribution'))] + UBUNTU_DISTROS
+    return [('', ugettext_lazy('Distribution'))] + UBUNTU_DISTROS.items();

--- a/inyoka/forum/migrations/0011_clean_ubuntu_distros.py
+++ b/inyoka/forum/migrations/0011_clean_ubuntu_distros.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        orm.Topic.objects.filter(ubuntu_distro='unity') \
+                         .update(ubuntu_distro='ubuntu')
+        orm.Topic.objects.filter(ubuntu_distro='kubuntu-kde4') \
+                         .update(ubuntu_distro='kubuntu')
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'forum.attachment': {
+            'Meta': {'object_name': 'Attachment'},
+            'comment': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mimetype': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'post': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'attachments'", 'null': 'True', 'to': u"orm['forum.Post']"})
+        },
+        u'forum.forum': {
+            'Meta': {'object_name': 'Forum'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'force_version': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_post': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Post']", 'null': 'True', 'on_delete': 'models.PROTECT', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'newtopic_default_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'_children'", 'null': 'True', 'on_delete': 'models.PROTECT', 'to': u"orm['forum.Forum']"}),
+            'position': ('django.db.models.fields.IntegerField', [], {'default': '0', 'db_index': 'True'}),
+            'post_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'slug': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100', 'db_index': 'True'}),
+            'topic_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user_count_posts': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'welcome_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.WelcomeMessage']", 'null': 'True', 'on_delete': 'models.SET_NULL', 'blank': 'True'})
+        },
+        u'forum.poll': {
+            'Meta': {'object_name': 'Poll'},
+            'end_time': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'multiple_votes': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'question': ('django.db.models.fields.CharField', [], {'max_length': '250'}),
+            'start_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'polls'", 'null': 'True', 'to': u"orm['forum.Topic']"})
+        },
+        u'forum.polloption': {
+            'Meta': {'object_name': 'PollOption'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '250'}),
+            'poll': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'options'", 'to': u"orm['forum.Poll']"}),
+            'votes': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        u'forum.pollvote': {
+            'Meta': {'object_name': 'PollVote', 'db_table': "'forum_voter'"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'poll': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'votings'", 'to': u"orm['forum.Poll']"}),
+            'voter': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['portal.User']"})
+        },
+        u'forum.post': {
+            'Meta': {'object_name': 'Post'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['portal.User']", 'on_delete': 'models.PROTECT'}),
+            'has_attachments': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'has_revision': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_plaintext': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'db_index': 'True'}),
+            'pub_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow', 'db_index': 'True'}),
+            'rendered_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'topic': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'posts'", 'on_delete': 'models.PROTECT', 'to': u"orm['forum.Topic']"})
+        },
+        u'forum.postrevision': {
+            'Meta': {'object_name': 'PostRevision'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'post': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'revisions'", 'to': u"orm['forum.Post']"}),
+            'store_date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        },
+        u'forum.privilege': {
+            'Meta': {'object_name': 'Privilege'},
+            'forum': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['forum.Forum']"}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['portal.Group']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'negative': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'}),
+            'positive': ('django.db.models.fields.IntegerField', [], {'default': '0', 'null': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['portal.User']", 'null': 'True'})
+        },
+        u'forum.topic': {
+            'Meta': {'object_name': 'Topic'},
+            'author': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'topics'", 'on_delete': 'models.PROTECT', 'to': u"orm['portal.User']"}),
+            'first_post': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.PROTECT', 'to': u"orm['forum.Post']"}),
+            'forum': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'topics'", 'on_delete': 'models.PROTECT', 'to': u"orm['forum.Forum']"}),
+            'has_poll': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_post': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.PROTECT', 'to': u"orm['forum.Post']"}),
+            'locked': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'post_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'report_claimed_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.PROTECT', 'to': u"orm['portal.User']"}),
+            'reported': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'reporter': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'+'", 'null': 'True', 'on_delete': 'models.PROTECT', 'to': u"orm['portal.User']"}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'solved': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sticky': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'ubuntu_distro': ('django.db.models.fields.CharField', [], {'max_length': '40', 'null': 'True', 'blank': 'True'}),
+            'ubuntu_version': ('django.db.models.fields.CharField', [], {'max_length': '5', 'null': 'True', 'blank': 'True'}),
+            'view_count': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        u'forum.welcomemessage': {
+            'Meta': {'object_name': 'WelcomeMessage'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'rendered_text': ('django.db.models.fields.TextField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '120'})
+        },
+        u'portal.group': {
+            'Meta': {'object_name': 'Group'},
+            'icon': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80', 'db_index': 'True'}),
+            'permissions': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        u'portal.user': {
+            'Meta': {'object_name': 'User'},
+            '_permissions': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            '_primary_group': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'primary_users_set'", 'null': 'True', 'db_column': "'primary_group_id'", 'to': u"orm['portal.Group']"}),
+            'aim': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'avatar': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'banned_until': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'coordinates_lat': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'coordinates_long': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.utcnow'}),
+            'email': ('django.db.models.fields.EmailField', [], {'unique': 'True', 'max_length': '50', 'db_index': 'True'}),
+            'forum_last_read': ('django.db.models.fields.IntegerField', [], {'default': '0', 'blank': 'True'}),
+            'forum_read_status': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'forum_welcome': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'gpgkey': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'user_set'", 'blank': 'True', 'to': u"orm['portal.Group']"}),
+            'icq': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'interests': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'jabber': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'launchpad': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'location': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'member_title': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'msn': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'occupation': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'post_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'settings': ('django.db.models.TextField', [], {'default': '{}'}),
+            'signature': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'sip': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'skype': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30', 'db_index': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'}),
+            'wengophone': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'yim': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['forum', 'forum']
+    symmetrical = True

--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -34,7 +34,7 @@ from django.contrib.contenttypes.models import ContentType
 from inyoka.forum.acl import (CAN_READ, get_privileges, filter_visible,
     check_privilege, filter_invisible)
 from inyoka.forum.constants import (CACHE_PAGES_COUNT, POSTS_PER_PAGE,
-    SUPPORTED_IMAGE_TYPES, UBUNTU_DISTROS_LEGACY)
+    SUPPORTED_IMAGE_TYPES, UBUNTU_DISTROS)
 from inyoka.markup import parse, RenderContext
 from inyoka.portal.models import SearchQueue, Subscription
 from inyoka.portal.user import User, Group
@@ -549,7 +549,7 @@ class Topic(models.Model):
             return _(u'No Ubuntu')
         out = []
         if self.ubuntu_distro:
-            out.append(UBUNTU_DISTROS_LEGACY[self.ubuntu_distro])
+            out.append(UBUNTU_DISTROS[self.ubuntu_distro])
         if self.ubuntu_version and self.ubuntu_version != u'none':
             out.append(force_unicode(self.get_ubuntu_version()))
         return u' '.join(force_unicode(x) for x in out)


### PR DESCRIPTION
After  #248 and an update of the database the legacy distribution choices aren't necessary anymore.
This PR will remove them
