### PR TITLE
Rename 'Advanced Search' as 'Filter'

### DIFF
--- a/inyoka/forum/templates/forum/page.html
+++ b/inyoka/forum/templates/forum/page.html
@@ -20,7 +20,7 @@
   <div class="dropdown">
     <ul class="dropdown">
       <li>
-        <a href="{{ href('portal', 'search', advanced=True) }}">{% trans %}Filter{% endtrans %}</a>
+        <span>{% trans %}Filter{% endtrans %}</span>
       </li>
       <li>
         <ul>

--- a/inyoka/static/style/main.less
+++ b/inyoka/static/style/main.less
@@ -1096,11 +1096,12 @@ ul.dropdown {
   }
 
   > li:first-child {
-    a {
+    span {
       padding-left: 15px;
       background-image: url(../img/arrow-down.gif);
       background-position: left;
       background-repeat: no-repeat;
+      color: @orange_s_medium;
     }
   }
 }
@@ -1118,7 +1119,7 @@ ul.dropdown:hover {
   > li:first-child {
     padding: 0 0 0.5em 0;
     border-bottom: 1px solid #d4d4d4;
-    a {
+    span {
       background-image: url(../img/arrow-up.gif);
     }
   }

--- a/inyoka/wiki/templates/wiki/page.html
+++ b/inyoka/wiki/templates/wiki/page.html
@@ -32,10 +32,13 @@
 {% block pathbar_extensions %}
   <div class="dropdown">
     <ul class="dropdown">
-      <li><a href="{{ href('portal', 'search') }}">{% trans %}Advanced search{% endtrans %}</a></li>
+      <li>
+        <span>{% trans %}Overview{% endtrans %}</span>
+      </li>
       <li>
         <ul>
           <li><a href="{{ href('wiki', 'Wiki', 'Letzte Änderungen') }}">{% trans %}Recent changes{% endtrans %}</a></li>
+          <li><a href="{{ href('wiki', 'Wiki', 'Index') }}">{% trans %}Index{% endtrans %}</a></li>
           <li><a href="{{ href('wiki', 'Wiki', 'Tags') }}">{% trans %}Tags{% endtrans %}</a></li>
         </ul>
       </li>


### PR DESCRIPTION
Some members of the ubuntuusers team wants to rename 'Advanced Search' as 'Filter'.
