### PR TITLE
Exclude resources from static and media subdomains from session managment

### DIFF
--- a/inyoka/utils/sessions.py
+++ b/inyoka/utils/sessions.py
@@ -27,8 +27,9 @@ def set_session_info(request):
     """Set the session info."""
 
     # Prevent extra queries for markup.css and jsi18n since they are loaded
-    # with every request.
-    if request.path in ('/markup.css/', '/jsi18n/'):
+    # with every request, in development this also prevents extra queries for
+    # static files. In production these files are served by another server.
+    if request.path in ('/markup.css/', '/jsi18n/') or request.subdomain in ('static', 'media'):
         return
 
     # if the session is new we don't add an entry.  It could be that


### PR DESCRIPTION
Errors occured when a user tried to log out, multiple session keys were
created. By excluding static files this is fixed.
