### PR TITLE
Show name of offending user in spam report.

### DIFF
--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -965,7 +965,7 @@ class Post(models.Model, LockableObject):
                     '[user:%(username)s:]: The post [post:%(post)s:] is hidden '
                     'due to possible spam.'
                 ) % {
-                    'username': User.objects.get_system_user().username,
+                    'username': self.author.username,
                     'post': self.pk,
                 }
                 if topic.reported:


### PR DESCRIPTION
When reporting automatically hidden spam posts, show the name of the
author instead of the generic system user.
