### PR TITLE
Redirect to 'Change password' after a password was changed

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -613,7 +613,7 @@ def usercp_password(request):
             user.set_password(data['new_password'])
             user.save()
             messages.success(request, _(u'Your password was changed successfully.'))
-            return HttpResponseRedirect(href('portal', 'usercp'))
+            return HttpResponseRedirect(href('portal', 'usercp', 'password'))
         else:
             generic.trigger_fix_errors_message(request)
     else:


### PR DESCRIPTION
Previous the user was redirected to the settings hub. But the default
layout doesn't use this hubs anymore, so changing a password resulted in a
template not found exception.
