### PR TITLE
Change the max_length to 255 for metadata values

### DIFF
--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -1275,7 +1275,7 @@ class MetaData(models.Model):
     """
     page = models.ForeignKey(Page)
     key = models.CharField(max_length=30, db_index=True)
-    value = models.CharField(max_length=512, db_index=True)
+    value = models.CharField(max_length=255, db_index=True)
 
 
 # imported here because of circular references


### PR DESCRIPTION
For an InnoDB 255 is the max key length, if uft-8 is used. Because it
assumes that every char needs the maximum of 3 bytes. An key can not be
longer than 767 bytes, so you can not set more than 255 chars.

Since this limit is only valid for the indexed keys another fix would be
not to index this field.

---

Since I am unsure about the consequences with the current productive database, any worries and better fixes for this problem are welcome.
