### PR TITLE
Fix delete polls when no topic exists.

### DIFF
--- a/inyoka/forum/views.py
+++ b/inyoka/forum/views.py
@@ -333,9 +333,10 @@ def handle_polls(request, topic, poll_ids):
                 request,
                 _(u'The poll “%(poll)s” was removed.') % {'poll': poll.question}
             )
-            topic.has_poll = Poll.objects \
-                .filter(Q(topic=topic) & ~Q(id=poll.id)) \
-                .exists()
+            if topic is not None:
+                topic.has_poll = Poll.objects \
+                    .filter(Q(topic=topic) & ~Q(id=poll.id)) \
+                    .exists()
             poll.delete()
     query = Poll.objects.filter(topic=topic)
     if poll_ids:


### PR DESCRIPTION
Do not try to set `topic.has_poll` when topic does not exist. This occurs if users create a topic, add a poll and then try to delete the poll before the topic is created.
