### PR TITLE
Bring installation instructions up to date with django 1.7

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,7 @@ Then you need to add your *public* key to your profile in Github under
 Getting access to the Inyoka repository
 ***************************************
 
-Then you need to write to `a developer <https://github.com/encbladexp>`_
+Then you need to contact `a developer <https://github.com/encbladexp>`_
 so that you get the correct access rights to fork the project.  Simply
 klick the "Fork" Button on `<https://github.com/inyokaproject/inyoka>`_ to
 create a new *private* Fork of this Repository.
@@ -101,7 +101,7 @@ files:
 
   $  sudo apt-get install libxml2-dev libxslt1-dev
   libzmq-dev zlib1g-dev libjpeg-dev uuid-dev libfreetype6-dev
-  libmysqlclient-dev build-essential
+  libmysqlclient-dev build-essential redis-server
 
 Further you need the Python 2.7 files:
 
@@ -137,8 +137,8 @@ Next you can start the actual Inyoka installation:
 .. code-block:: console
 
   $ mkdir -p ~/.venvs/inyoka
-  $ virtualenv-2.7 ~/.venvs/inyoka
-  $ ~/.venvs/inyoka/bin/pip install -r extra/requirements/test.txt
+  $ virtualenv ~/.venvs/inyoka
+  $ ~/.venvs/inyoka/bin/pip install -r extra/requirements/development.txt
 
 Note: You need to cd to your inyoka directory for the last command to work.
 
@@ -256,7 +256,6 @@ development installation:
 
 .. code-block:: console
 
-  (inyoka)$ python manage.py syncdb
   (inyoka)$  python manage.py migrate
   (inyoka)$  python manage.py create_superuser
   username: admin

--- a/make_testdata.py
+++ b/make_testdata.py
@@ -13,6 +13,7 @@ from __future__ import division
 import os
 import math
 import time
+import django
 from random import choice, randint
 from datetime import datetime
 from itertools import izip
@@ -32,7 +33,7 @@ from inyoka.ikhaya.models import Comment, Article, Category
 from inyoka.utils.captcha import generate_word
 from inyoka.planet.models import Blog
 from inyoka.utils.terminal import show, percentize, ProgressBar
-from inyoka.scripts.planet_sync import sync
+from inyoka.planet.tasks import sync
 
 MARKS = ('.', ';', '!', '?')
 WORDS = LOREM_IPSUM_WORDS.split(' ')
@@ -261,6 +262,7 @@ def make_planet():
 
 
 if __name__ == '__main__':
+    django.setup()
     page_names = ['Startseite', 'Welcome'] + list(create_names(WIKI_PAGES_COUNT))
     make_groups()
     make_users()


### PR DESCRIPTION
These were tested on Ubuntu 14.04
- Added redis-server dependency.
- Changed name of requirements.
- virtualenv-2.7 does not exist in Ubuntu 14.04.
- manage.py syncdb is deprecated in django 1.7, use migrate instead.
- Standalone django scripts (make_testdata.py) need to call django.setup()
- make_testdata.py needs to use planet.tasks instead of the old script.
