### PR TITLE
Use https on gravatar pics

### DIFF
--- a/inyoka/utils/gravatar.py
+++ b/inyoka/utils/gravatar.py
@@ -14,9 +14,9 @@ from hashlib import md5
 
 import requests
 
-BASE_URL = 'http://www.gravatar.com/avatar/'
+BASE_URL = 'https://www.gravatar.com/avatar/'
 SECURE_BASE_URL = 'https://secure.gravatar.com/avatar/'
-PROFILE_URL = 'http://www.gravatar.com/'
+PROFILE_URL = 'https://www.gravatar.com/'
 RATINGS = ('g', 'pg', 'r', 'x')
 MAX_SIZE = 512
 MIN_SIZE = 1


### PR DESCRIPTION
From IRC:

<Vej> Kann mir jemand verraten, warum alte Themen im Firefox als "unsichere Verbindung" angezeigt werden und neuere nicht?
<Vej> Ein Beispiel: Die erste Seite von https://forum.ubuntuusers.de/topic/personalbedarf-ii/ ist "nicht sicher", die letzte schon.
<redknight> Vej: Wild geraten: Es werden noch bils per http nachgeladen oder das CSS oder so
<Vej> redknight: Danke für die Antwort, aber was sind bils? Sollte ich die kennen?
<redknight> bilder
<Vej> redknight: Ah! Klar, danke.
<redknight> Du musst doch so wissen, was ich meine :D
<redknight> <-- Fingerkuppenlegasthenie
<Vej> _Lacht_
<Vej> redknight: Deine Theorie könnte stimmen, denn der Planet lädt ja auch Bilder nach und erzeugt die gleiche Warnmeldung in meinem Firefox.
<Vej> redknight: Also brauche ich das eher nicht zu melden oder?
<redknight> Wenn es so ist, wie ich vermute, stehen noch irgendwo in der db http-Links. Ich glaube nciht, dass jemand sich auf die Suche machen will ;)
