### PR TITLE
Use different redis test prefixes for different tests settings so the…

### DIFF
--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -35,7 +35,7 @@ INYOKA_AKISMET_KEY = 'inyokatestkey'
 INYOKA_AKISMET_URL = 'http://testserver/'
 
 CACHES['content']['LOCATION'] = 'redis://127.0.0.1:6379/0'
-CACHES['content']['KEY_PREFIX'] = 'inyoka-test'
+CACHES['content']['KEY_PREFIX'] = 'test-base'
 
 CACHES['default']['LOCATION'] = 'redis://127.0.0.1:6379/1'
-CACHES['default']['KEY_PREFIX'] = 'inyoka-test'
+CACHES['default']['KEY_PREFIX'] = 'test-base'

--- a/tests/settings/mysql.py
+++ b/tests/settings/mysql.py
@@ -10,3 +10,6 @@ DATABASES = {
         'PORT': '',
     }
 }
+
+CACHES['content']['KEY_PREFIX'] = 'test-mysql'
+CACHES['default']['KEY_PREFIX'] = 'test-mysql'

--- a/tests/settings/sqlite.py
+++ b/tests/settings/sqlite.py
@@ -1,3 +1,4 @@
 from .base import *  # noqa
 
-# Stub to contain the correct database naming.
+CACHES['content']['KEY_PREFIX'] = 'test-sqlite'
+CACHES['default']['KEY_PREFIX'] = 'test-sqlite'


### PR DESCRIPTION
…y can be run in parallel
