### PR TITLE
Fix wrong variable name in create article form

### DIFF
--- a/inyoka/wiki/forms.py
+++ b/inyoka/wiki/forms.py
@@ -58,7 +58,7 @@ class NewArticleForm(SurgeProtectionMixin, forms.Form):
         # If user has no right to create the article, alter the name to include
         # the "construction" prefix.
         if not has_privilege(self.user, name, 'create'):
-            name = join_pagename(storage['wiki_construction_area'], name)
+            name = join_pagename(storage['wiki_newpage_root'], name)
             # See if the user now has the right to create this page.
             if not has_privilege(self.user, name, 'create'):
                 # This could mean that the page exists and was previously


### PR DESCRIPTION
Clear oversight on my part. When creating new articles, if the user does
not have the right to create the article, it's supposed to be created in a
construction area instead. Since I used the wrong variable name, this never
returned the name of the construction area and it never worked as intended.

Follow up to #321 
