### PR TITLE
Fixed link to tag cloud

### DIFF
--- a/inyoka/wiki/urls.py
+++ b/inyoka/wiki/urls.py
@@ -20,6 +20,7 @@ urlpatterns = patterns('inyoka.wiki.views',
     (r'^(?P<page_name>.+)/a/feed/?$', 'feed', {'count': 10}),
     (r'^(?P<page_name>.+)/a/feed/(?P<count>\d+)/?$', 'feed'),
     (r'(?i)^wiki/recentchanges', 'recentchanges'),
+    (r'(?i)^wiki/tagcloud$', 'show_tag_cloud'),
     (r'(?i)^wiki/tags$', 'show_tag_list'),
     (r'(?i)^wiki/tags/(?P<tag>.+)', 'show_pages_by_tag')
     )


### PR DESCRIPTION
Link to tag cloud has been removed unintentionally: https://github.com/inyokaproject/inyoka/commit/c925b9facfc50613b0fc3d0ea824318312d368a2#diff-fdb177be6cf194256cc061243b0946fdL24
See also inyokaproject/theme-ubuntuusers#115
