### PR TITLE
fix Article.get_latest_articles()

### DIFF
--- a/inyoka/ikhaya/models.py
+++ b/inyoka/ikhaya/models.py
@@ -106,7 +106,8 @@ class ArticleManager(models.Manager):
             articles = Article.published.order_by('-updated') \
                                         .values_list('pub_date', 'slug')
             if category:
-                articles.filter(category__slug=category)
+                articles = articles.filter(category__slug=category)
+
             maxcount = max(settings.AVAILABLE_FEED_COUNTS['ikhaya_feed_article'])
             articles = list(articles[:maxcount])
             cache.set(key, articles, 1200)


### PR DESCRIPTION
Enables getting the latest articles of a certain Ikhaya category.

This also fixes part of http://trac.inyokaproject.org/ticket/837, ie the Ikhaya category feeds work now.
