### PR TITLE
Wiki change default create link

### DIFF
--- a/inyoka/portal/forms.py
+++ b/inyoka/portal/forms.py
@@ -787,10 +787,11 @@ class ConfigurationForm(forms.Form):
         label=ugettext_lazy(u'Default text of new wiki pages'))
     wiki_newpage_root = forms.CharField(required=False,
         label=ugettext_lazy(u'Location of new wiki pages'))
-    wiki_newpage_infopage = forms.CharField(required=False,
-        label=ugettext_lazy(u'Information page about new wiki pages'),
-        help_text=ugettext_lazy(u'Information page to which a “create” link should '
-                    u'redirect to.'))
+    wiki_newpage_help = forms.CharField(required=False,
+        widget=forms.Textarea(attrs={'rows': 5}),
+        label=ugettext_lazy(u'Help text for new wiki article form.'),
+        help_text=ugettext_lazy(u'This text appears above the form to create new '
+                                u'wiki articles.'))
     wiki_edit_note = forms.CharField(required=False,
         widget=forms.Textarea(attrs={'rows': 5}),
         label=ugettext_lazy(u'Wiki helptext'),

--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -1672,7 +1672,7 @@ def config(request):
     keys = ['welcome_message', 'max_avatar_width', 'max_avatar_height', 'max_avatar_size',
             'max_signature_length', 'max_signature_lines', 'get_ubuntu_link',
             'license_note', 'get_ubuntu_description', 'blocked_hosts', 'wiki_edit_note',
-            'wiki_newpage_template', 'wiki_newpage_root', 'wiki_newpage_infopage', 'wiki_edit_note',
+            'wiki_newpage_template', 'wiki_newpage_root', 'wiki_newpage_help', 'wiki_edit_note',
             'team_icon_height', 'team_icon_width', 'distri_versions',
             'countdown_active', 'countdown_target_page', 'countdown_image_url',
             'ikhaya_description', 'planet_description']

--- a/inyoka/wiki/actions.py
+++ b/inyoka/wiki/actions.py
@@ -197,11 +197,6 @@ def do_missing_page(request, name, _page=None):
         else:
             create_link = None
 
-    # If there's an info page for the creation of new pages configured
-    # we overwrite that create_link to that configuration.
-    if create_link is not None:
-        create_link = storage['wiki_newpage_infopage'] or create_link
-
     try:
         not_finished = Page.objects.get_by_name(join_pagename(
             storage['wiki_newpage_root'], name
@@ -411,7 +406,10 @@ def do_create(request, name=None):
         if name is not None:
             form.initial = {'name': name}
 
-    return {'form': form}
+    return {
+        'help_text': storage.get('wiki_newpage_help_rendered', u''),
+        'form': form
+    }
 
 
 @clean_article_name


### PR DESCRIPTION
For internationalization we should always link to the main create view.

Up until recently, we had a macro to embed in a wiki article – this article
was linked to based on a setting `wiki_newpage_infopage`.
This drops the old setting in favor of a configurable help text, to be
displayed on the create view.

(See also changes to templates)
