### PR TITLE
Sort Tags using the current locale

### DIFF
--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -153,11 +153,12 @@ class PageManager(models.Manager):
         if revs:
             return revs[0]
 
-    def get_tagcloud(self, show_max=100):
+    def get_taglist(self, show_max=None):
         """
-        Get a tagcloud.  Note that this is one of the few operations that
-        also returns attachments, not only pages.  A tag cloud is represented
-        as ordinary list of dicts with the following keys:
+        Get a list of all tags or just the most used ones (if show_max is
+        set). Note that this is one of the few operations that also returns
+        attachments, not only pages.  The tag list is an ordinary list of
+        dicts with the following keys:
 
         ``'name'``
             The name of the tag

--- a/inyoka/wiki/views.py
+++ b/inyoka/wiki/views.py
@@ -239,15 +239,15 @@ def show_tag_list(request):
     """
     Show an alphabetical tag list with all wiki tags.
     """
-    return {'tag_list': Page.objects.get_tagcloud(None)}
+    return {'tag_list': Page.objects.get_taglist()}
 
 
 @templated('wiki/tag_cloud.html')
 def show_tag_cloud(request):
     """
-    Show a tag cloud.
+    Show a tag cloud of the 100 most used tags.
     """
-    return {'tag_list': Page.objects.get_tagcloud()}
+    return {'tag_list': Page.objects.get_taglist(100)}
 
 
 @templated('wiki/pages_by_tag.html')


### PR DESCRIPTION
Actually the sorting of the tags ignores locale rules. For example:
- Aktualisierung
- Ziffernblock
- Übersicht

Should rather be (with German locale):
- Aktualisierung
- Übersicht
- Ziffernblock

Can be solved with locale.strxfrm() as mentioned here: https://wiki.python.org/moin/HowTo/Sorting
