### PR TITLE
Sort Tags using the current locale

### DIFF
--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -96,6 +96,9 @@ INYOKA_LOGGER_NAME = u'inyoka'
 # use etags
 USE_ETAGS = True
 
+# maximal number of tags shown in the tag cloud
+TAGCLOUD_SIZE = 100
+
 # prefix for the system mails
 EMAIL_SUBJECT_PREFIX = u'%s: ' % BASE_DOMAIN_NAME
 

--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -153,11 +153,12 @@ class PageManager(models.Manager):
         if revs:
             return revs[0]
 
-    def get_tagcloud(self, show_max=100):
+    def get_taglist(self, size_limit=None):
         """
-        Get a tagcloud.  Note that this is one of the few operations that
-        also returns attachments, not only pages.  A tag cloud is represented
-        as ordinary list of dicts with the following keys:
+        Get a list of all tags or just the most used ones (if size_limit is
+        set). Note that this is one of the few operations that also returns
+        attachments, not only pages.  The tag list is an ordinary list of
+        dicts with the following keys:
 
         ``'name'``
             The name of the tag
@@ -173,8 +174,8 @@ class PageManager(models.Manager):
         tags = MetaData.objects.filter(key='tag').values_list('value')\
             .annotate(count=Count('value'))\
             .order_by('-count')
-        if show_max is not None:
-            tags = tags[:show_max]
+        if size_limit is not None:
+            tags = tags[:size_limit]
 
         # set locale, so that the list is being sorted in respect to it
         locale.setlocale(locale.LC_ALL, default_settings.LC_ALL)

--- a/inyoka/wiki/views.py
+++ b/inyoka/wiki/views.py
@@ -239,15 +239,15 @@ def show_tag_list(request):
     """
     Show an alphabetical tag list with all wiki tags.
     """
-    return {'tag_list': Page.objects.get_tagcloud(None)}
+    return {'tag_list': Page.objects.get_taglist()}
 
 
 @templated('wiki/tag_cloud.html')
 def show_tag_cloud(request):
     """
-    Show a tag cloud.
+    Show a tag cloud of the 100 most used tags.
     """
-    return {'tag_list': Page.objects.get_tagcloud()}
+    return {'tag_list': Page.objects.get_taglist(settings.TAGCLOUD_SIZE)}
 
 
 @templated('wiki/pages_by_tag.html')


### PR DESCRIPTION
Actually the sorting of the tags ignores locale rules. For example:

```
Aktualisierung
Ziffernblock
Übersicht
```

Should rather be (with German locale):

```
Aktualisierung
Übersicht
Ziffernblock
```

Has been solved using locale.strcoll() as mentioned here: https://wiki.python.org/moin/HowTo/Sorting
works with python 2.x in contrast to #442 
solves #444 
(thanks to chris34 for pointing at strcoll)
