### PR TITLE
Harmonized labels for forum-filter "involved topics"

### DIFF
--- a/inyoka/forum/views.py
+++ b/inyoka/forum/views.py
@@ -1618,7 +1618,7 @@ def topiclist(request, page=1, action='newposts', hours=24, user=None, forum=Non
             title = _(u'Posts by “%(user)s”') % {'user': user.username}
             url = href('forum', 'author', user.username, forum)
         else:
-            title = _(u'My posts')
+            title = _(u'Involved topics')
             url = href('forum', 'egosearch', forum)
     elif action == 'newposts':
         forum_ids = tuple(forum.id for forum in Forum.objects.get_cached())


### PR DESCRIPTION
The title of the view diverged with the linktext of the forum-filter.

introduced with https://github.com/inyokaproject/theme-ubuntuusers/pull/121

reported in https://forum.ubuntuusers.de/post/7927768/
