### PR TITLE
Update django-host to version 1.3 to get rid of a deprication warning on

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -5,7 +5,7 @@ celery==3.1.19
 defusedxml==0.4.1
 Django==1.8.7
 django-filter==0.11.0
-django-hosts==1.2
+django-hosts==1.3
 django-mobile==0.5.1
 django-redis==4.2.0
 dnspython==1.12.0


### PR DESCRIPTION
startup
