### PR TITLE
Create the possibility to run tests on different database servers

### DIFF
--- a/tests/settings/README
+++ b/tests/settings/README
@@ -1,0 +1,17 @@
+In this folder are settings to test inyoka with different dabaseses.
+
+To run the tests, call:
+
+python manage.py --settings tests.settings.DATABASE
+
+where DATABASE is sqlite, mysql or postgres.
+
+To run the tests with a specific database server, the database has to be
+installed and configured. There has also be a redis server for the tests to
+work.
+
+As default, the tests expect the database servers to run on localhost, but
+another host can be used by creating a file custom.py in the settings folder
+with the content:
+
+test_host = MY_HOST_NAME

--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -2,6 +2,13 @@ from uuid import uuid1
 
 from inyoka.default_settings import *  # NOQA
 
+try:
+    from .custom import test_host
+except ImportError:
+    # The file custom.py is optional. If it does not exist, then use an empty
+    # string test_host.
+    test_host = ''
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -36,8 +43,11 @@ SECRET_KEY = 'test-secret-key'
 INYOKA_AKISMET_KEY = 'inyokatestkey'
 INYOKA_AKISMET_URL = 'http://testserver/'
 
-CACHES['content']['LOCATION'] = 'redis://127.0.0.1:6379/0'
+CACHES['content']['LOCATION'] = 'redis://{}:6379/0'.format(test_host or 'localhost')
 CACHES['content']['KEY_PREFIX'] = uuid1()
 
-CACHES['default']['LOCATION'] = 'redis://127.0.0.1:6379/1'
+CACHES['default']['LOCATION'] = 'redis://{}:6379/1'.format(test_host or 'localhost')
 CACHES['default']['KEY_PREFIX'] = uuid1()
+
+BROKER_URL = 'redis://{}:6379/0'.format(test_host or 'localhost')
+CELERY_RESULT_BACKEND = 'redis://{}:6379/0'.format(test_host or 'localhost')

--- a/tests/settings/mysql.py
+++ b/tests/settings/mysql.py
@@ -7,8 +7,6 @@ DATABASES = {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'inyoka_{}'.format(uuid1()),
         'USER': 'root',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
+        'HOST': test_host,
     }
 }

--- a/tests/settings/postgresql.py
+++ b/tests/settings/postgresql.py
@@ -7,5 +7,6 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'inyoka_{}'.format(uuid1()),
         'USER': 'postgres',
+        'HOST': test_host,
     }
 }


### PR DESCRIPTION
which do not run on localhost, at the same time.

To run tests there have to be different database servers. The tests try to connect
to this servers on localhost as default. To specify a different host, a file
custom.py has to be created.

Before this commit the custom file had to be used as settings, so it could not
be configured for different databases at the same time. With this commit, the
tests are started my choosing not the custom-settings, but the "normal" setting
like tests.settings.mysql or tests.settings.postgresql.

See the created README for more information
