### PR TITLE
Fix race conditions on the test run.

### DIFF
--- a/inyoka/utils/cache.py
+++ b/inyoka/utils/cache.py
@@ -186,3 +186,14 @@ class RedisCache(_RedisCache):
             # If value can not be decoded, then delete it from the cache
             redis.delete(key)
             raise
+
+    def clear(self, client=None):
+        """
+        Flush all cache keys.
+        """
+        # The implementation of django-redis flushes the hole database and
+        # ignores the KEY_PREFIX set in the configuration.
+        # See https://github.com/niwinz/django-redis/issues/168
+        # This method can be deleted when the issue is fixed or when all calls
+        # to cache.clear() are deleted.
+        self.delete_pattern("*", client=client)


### PR DESCRIPTION
We want to run the tests in parallel (postgresql, mysql and sqlite at the same time).
But each test run uses the same redis db. Therefore we work with different key-prefixes
so that each test runner has its own cache keys.

The current version of django-redis has a but that cache.clear() ignores the key-prefix-
settings and flushes the hole database. See https://github.com/niwinz/django-redis/issues/168

This commit solves this problem until django-redis is fixed.
