### PR TITLE
Workaround for Wiki Metadata Update.

### DIFF
--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -884,7 +884,9 @@ class Page(models.Model):
         if self.rev is not None:
             self.rev.save()
         deferred.clear(self)
-        update_related_pages.delay(self, update_meta)
+        # FIXME: We are using apply_async() instead of delay() because there is
+        #        a real dumb race condition between the celery task and this save().
+        update_related_pages.apply_async(args=[self, update_meta], countdown=5)
 
     def delete(self):
         """


### PR DESCRIPTION
Since Django 1.8 Wiki Metadata gets no longer updated on Page.save(), it seems
to be an race condition between save() and update_related_pages(). This is a
simple workaround for the Problem, not an Solution!

Caveats: Metadata gets updated 5 seconds after saving the page object.
