### PR TITLE
Fix on_toggle_sidebar() Service.

### DIFF
--- a/inyoka/portal/services.py
+++ b/inyoka/portal/services.py
@@ -108,7 +108,7 @@ def on_toggle_sidebar(request):
     if request.GET.get('hide') == 'true':
         request.user.settings[component] = True
     else:
-        request.user.settings.pop(component)
+        request.user.settings.pop(component, None)
     request.user.save(update_fields=['settings'])
     return True
 


### PR DESCRIPTION
If, for any possible or inpossible reason, a Users settings Dictionary (User.settings) doesn't
have an field, we should Default pop() Operations to avoid KeyErrors.

This happened on http://sentry.lan-cgn:9000/ubuntuusers/production/group/169/. Using a check with
has_key() is possible, but wastes time for things we dont need.
