### PR TITLE
Fix make_textdata.py

### DIFF
--- a/make_testdata.py
+++ b/make_testdata.py
@@ -19,6 +19,9 @@ from random import choice, randint
 
 import django
 from django.conf import settings
+if 'DJANGO_SETTINGS_MODULE' not in os.environ:
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'development_settings'
+
 from jinja2.constants import LOREM_IPSUM_WORDS
 
 from inyoka.forum.models import Forum, Post, Topic
@@ -31,8 +34,6 @@ from inyoka.utils.terminal import ProgressBar, percentize, show
 from inyoka.utils.text import increment_string
 from inyoka.wiki.models import Page
 
-if 'DJANGO_SETTINGS_MODULE' not in os.environ:
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'development_settings'
 settings.DEBUG = settings.DATABASE_DEBUG = False  # for nice progressbar output ;)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,10 +4,11 @@ tag_date = 0
 tag_svn_revision = 0
 
 [flake8]
-exclude = build,.*/
+exclude = build,.*/,./make_testdata.py
 ignore = E123,E128,E402,E501,W503,E731,W601
 max-line-length = 119
 
 [isort]
 include_trailing_comma = true
 multi_line_output = 3
+skip=./make_testdata.py


### PR DESCRIPTION
The settings have to be set to the development settings before the other
parts can be loaded even, if it is not conform with flake8.
