### PR TITLE
Ordered taglist by page-name

### DIFF
--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -413,8 +413,11 @@ class PageManager(models.Manager):
         return rv
 
     def find_by_tag(self, tag):
-        """Return a list of page names tagged with `tag`."""
-        pages = MetaData.objects.filter(key='tag', value=tag)\
+        """
+        Return a list of page names tagged with `tag`.
+        The list will be sorted alphabetically.
+        """
+        pages = MetaData.objects.filter(key='tag', value=tag).order_by('page__name')\
                                 .values_list('page__name', flat=True)
         return pages
 


### PR DESCRIPTION
Before, the return-value of `find_by_tag` were ordered by the page-id.
The only other occurrence – besides the [new view](https://github.com/inyokaproject/inyoka/blob/staging/inyoka/wiki/views.py#L262) – is in
https://github.com/inyokaproject/inyoka/blob/staging/inyoka/wiki/macros.py#L208
There, the tags are sorted afterwards with python.

see also http://trac.inyokaproject.org/ticket/974

Question: Let the DB or Python sort it?

`…wiki/tags/<X>` only accessible with #508 applied
