### PR TITLE
Wiki urls: Use trailing-slashes everywhere

### DIFF
--- a/inyoka/wiki/urls.py
+++ b/inyoka/wiki/urls.py
@@ -21,11 +21,11 @@ urlpatterns = [
     url(r'^_feed/(?P<count>\d+)/$', views.feed),
     url(r'^(?P<page_name>.+)/a/feed/$', views.feed, {'count': 10}),
     url(r'^(?P<page_name>.+)/a/feed/(?P<count>\d+)/$', views.feed),
-    url(r'(?i)^wiki/recentchanges', views.recentchanges),
-    url(r'(?i)^wiki/missingpages', views.missingpages),
-    url(r'(?i)^wiki/tagcloud$', views.show_tag_cloud),
-    url(r'(?i)^wiki/tags$', views.show_tag_list),
-    url(r'(?i)^wiki/tags/(?P<tag>.+)', views.show_pages_by_tag)
+    url(r'(?i)^wiki/recentchanges/$', views.recentchanges),
+    url(r'(?i)^wiki/missingpages/$', views.missingpages),
+    url(r'(?i)^wiki/tagcloud/$', views.show_tag_cloud),
+    url(r'(?i)^wiki/tags/$', views.show_tag_list),
+    url(r'(?i)^wiki/tags/(?P<tag>.+)/$', views.show_pages_by_tag)
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
After an (unindendet) change to use trailing-slashes in the wiki, some URLs
were not accessible. Requests without trailing-slashes will now be redirected
by the CommonMiddleware. So its an alternative to https://github.com/encbladexp/inyoka/commit/48494fdd9bdf49d1249b14a9e91d7517b464a027 and https://github.com/encbladexp/inyoka/commit/8ccc9d40da38ac697304ff3f424117f03e5c2e2b from #504 

Atm https://github.com/chris34/inyoka/blob/07e5b686476ec1f956204a1e65d0d0c7563efa85/inyoka/wiki/urls.py#L17-L20 are unchanged, as i have no idea what they are good for and how i could test them.
