### PR TITLE
Use native jinja2 backend provided by django.

### DIFF
--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -319,12 +319,18 @@ PASSWORD_HASHERS = (
     'inyoka.utils.user.UnsaltedMD5PasswordHasher',
 )
 
-TEMPLATE_LOADERS = (
-    'inyoka.utils.templating.DjangoLoader',
-    'django.template.loaders.app_directories.Loader',
-)
-
-TEMPLATE_CONTEXT_PROCESSORS = ()
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.jinja2.Jinja2',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'environment': 'inyoka.utils.templating.inyoka_environment',
+            'autoescape': False,
+            'extensions': ['jinja2.ext.i18n', 'jinja2.ext.do'],
+        },
+    },
+]
 
 ALLOWED_HOSTS = ['.ubuntuusers.de']
 

--- a/inyoka/utils/http.py
+++ b/inyoka/utils/http.py
@@ -45,8 +45,8 @@ def templated(template_name, status=None, modifier=None,
                 rv = {}
             if modifier is not None:
                 modifier(request, rv)
-            return TemplateResponse(template_name, rv, status=status,
-                                    content_type=content_type)
+            return TemplateResponse(template_name, rv, request=request,
+                                    status=status, content_type=content_type)
         return patch_wrapper(proxy, f)
     return decorator
 
@@ -71,11 +71,11 @@ class TemplateResponse(HttpResponse):
     """
     Returns a rendered template as response.
     """
-    def __init__(self, template_name, context, status=200,
+    def __init__(self, template_name, context, request, status=200,
                  content_type='text/html; charset=utf-8'):
         if settings.DEBUG or settings.PROPAGATE_TEMPLATE_CONTEXT:
             self.tmpl_context = context
-        tmpl = render_template(template_name, context)
+        tmpl = render_template(template_name, context, request)
         HttpResponse.__init__(self, tmpl, status=status,
                               content_type=content_type)
 


### PR DESCRIPTION
Scrap all our custom jinja environment, template class and loaders.
Use the default code provided by django.

WIP, currently this breaks a few things. Some template changes are required.

Some notes and ToDo:
- [ ] This gets rid of our own csrf-code and uses code from django. Make sure it's working correctly.
- [ ] `render_template()` now takes the `request` parameter, so I had to change the `@templated` decorator. Make sure nothing broke.
- [ ] `render_template()` needs to be changed to be aware of mobile templates!
- Clean up `populate_context_defaults()` which adds a whole lot of default variables to templates. We should figure out which ones we actually need, maybe move some stuff in the views and clean this up. Maybe in a new PR.
- Rendering Breadcrumbs is done in python? Determining what goes in the breadcrumb is done in the template? That's backwards, but a case for a different PR.
- There are some custom filters which I don't know if we really need them or if they can be replaced with django alternatives.
- `get_dtd()` seems completely pointless.
- Templates will spew errors in forms, we probably need to change `{{ form.errors['text'] }}` to `{% if form.errors['text'] %}{{ form.errors['text'] }}{% endif %}` in various places.
- I haven't run any tests with this, things probably broke.
