### PR TITLE
Add theme to example_development_settings

### DIFF
--- a/example_development_settings.py
+++ b/example_development_settings.py
@@ -30,6 +30,10 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 SECRET_KEY = None
 
+INSTALLED_APPS = INSTALLED_APPS + (
+    'inyoka_theme_default',
+)
+
 # Django Debug Toolbar Integration
 #
 # uncomment to activate debug toolbar support


### PR DESCRIPTION
Since you are unable to work with the basic backend without
any frontend, one theme should be added to the example configuration.
The default theme was choosen because the ubuntuusers theme will not
be open source.
