### PR TITLE
Remove breadcrumbs

### DIFF
--- a/inyoka/utils/templating.py
+++ b/inyoka/utils/templating.py
@@ -293,7 +293,8 @@ class InyokaEnvironment(Environment):
                              auto_reload=settings.DEBUG,
                              cache_size=-1)
 
-        self.globals.update(INYOKA_VERSION=INYOKA_VERSION,
+        self.globals.update(BASE_DOMAIN_NAME=settings.BASE_DOMAIN_NAME,
+                            INYOKA_VERSION=INYOKA_VERSION,
                             SETTINGS=settings,
                             REQUEST=current_request,
                             href=href,


### PR DESCRIPTION
Via inyokaproject/theme-ubuntuusers#143 all breadcrumbs and titles are rendered via jinja completly.
