### PR TITLE
Create System Groups (registered, anonymous, ikhaya) on demand.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -218,15 +218,6 @@ General
 
     Days to describe an inactive user
 
-Ikhaya
-------
-
-.. py:data:: IKHAYA_GROUP_ID
-
-    Defaults to: ``1``
-
-    The id of the ikhaya team group
-
 Wiki
 ----
 

--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -72,13 +72,19 @@ MEDIA_URL = '//media.%s/' % BASE_DOMAIN_NAME
 STATIC_ROOT = join(BASE_PATH, 'static-collected')
 STATIC_URL = '//static.%s/' % BASE_DOMAIN_NAME
 
-# system settings
+# system user and group related settings
 INYOKA_SYSTEM_USER = u'ubuntuusers.de'
-INYOKA_SYSTEM_USER_EMAIL = '@'.join(['system', BASE_DOMAIN_NAME])
 INYOKA_ANONYMOUS_USER = u'anonymous'
+INYOKA_IKHAYA_GROUP_NAME = u'ikhayateam'
+INYOKA_REGISTERED_GROUP_NAME = u'registered'
+INYOKA_ANONYMOUS_GROUP_NAME = u'anonymous'
+
+# E-Mail settings
+INYOKA_SYSTEM_USER_EMAIL = '@'.join(['system', BASE_DOMAIN_NAME])
 INYOKA_CONTACT_EMAIL = '@'.join(['contact', BASE_DOMAIN_NAME])
 DEFAULT_FROM_EMAIL = INYOKA_SYSTEM_USER_EMAIL
 
+# Disable portal registration, usefull in case of a spam problem
 INYOKA_DISABLE_REGISTRATION = False
 
 # Spam prevention
@@ -121,9 +127,6 @@ FORUM_DISABLE_POSTING = False
 USER_REACTIVATION_LIMIT = 31
 USER_SET_NEW_EMAIL_LIMIT = 7
 USER_RESET_EMAIL_LIMIT = 31
-
-# the id of the ikhaya team group
-IKHAYA_GROUP_ID = 1
 
 # settings for the jabber bot (client)
 JABBER_BOT_SERVER = 'tcp://127.0.0.1:6203'

--- a/inyoka/forum/acl.py
+++ b/inyoka/forum/acl.py
@@ -14,8 +14,7 @@ from django.db.models import Q
 from django.db.models.query import EmptyQuerySet
 from django.core.cache import cache
 from django.utils.translation import ugettext_lazy
-
-from inyoka.portal.user import DEFAULT_GROUP_ID
+from inyoka.portal.user import Group
 
 #: Mapping from privilege strings to human readable descriptions
 PRIVILEGES_DETAILS = [
@@ -122,7 +121,7 @@ def _get_privilege_map(user, forum_ids):
     from inyoka.forum.models import Privilege, Forum
     group_ids = set(user.groups.values_list('id', flat=True))
     if user.is_authenticated():
-        group_ids.add(DEFAULT_GROUP_ID)
+        group_ids.add(Group.objects.get_registered_group().id)
 
     cols = ('forum_id', 'user_id', 'group_id', 'positive', 'negative')
 

--- a/inyoka/planet/views.py
+++ b/inyoka/planet/views.py
@@ -88,8 +88,7 @@ def suggest(request):
     if request.method == 'POST':
         form = SuggestBlogForm(request.POST)
         if form.is_valid():
-            ikhaya_group = Group.objects.get(id=settings.IKHAYA_GROUP_ID)
-            users = ikhaya_group.user_set.all()
+            users = Group.objects.get_ikhaya_group().user_set.all()
             text = render_template('mails/planet_suggest.txt',
                                    form.cleaned_data)
             for user in users:
@@ -100,7 +99,7 @@ def suggest(request):
                 messages.error(request, _(u'No user is registered as a planet administrator.'))
                 return HttpResponseRedirect(href('planet'))
             messages.success(request, _(u'The blog “%(title)s” was suggested.')
-                                        % {'title': escape(form.cleaned_data['name'])})
+                             % {'title': escape(form.cleaned_data['name'])})
             return HttpResponseRedirect(href('planet'))
     else:
         form = SuggestBlogForm()


### PR DESCRIPTION
The three system groups (registered, anonymous, ikhayateam) are now created
on demand. This ensures that we have these always available.

This commit changes also from and ID based specification of system groups
to and name based one. This ensures that not any funny named group from
make_testdate gets any special meanings in the future.

In existing setups it is require to change settings.py accordingly.
