### PR TITLE
Made countdown on the portal-index available again

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -185,8 +185,7 @@ def index(request):
     })
 
     countdown_active = storage_values.get('countdown_active', False)
-    # The storage can only handle strings
-    countdown_active = (countdown_active == 'True')
+    countdown_active = countdown_active == True or countdown_active == 'True'
     countdown_date = storage_values.get('countdown_date', None)
     countdown_image_url = storage_values.get('countdown_image_url', None)
     if countdown_active and countdown_date:


### PR DESCRIPTION
After the migration to Redis the value for 'countdown_active' is now saved
as an bool in the storage.

Without this fix the countdown is currently unusable.
