### PR TITLE
Fix: deleted wiki discussions cause server errors

### DIFF
--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -611,11 +611,7 @@ class Topic(models.Model):
         Subscription.objects.filter(content_type=ctype, object_id=self.id).delete()
 
         # remove wiki page discussions and clear caches
-        wiki_pages = WikiPage.objects.filter(topic=self)
-        if wiki_pages.update(topic=None) > 0:
-            names = wiki_pages.values_list('name', flat=True)
-            keys = [u'wiki/page/{}'.format(n).lower() for n in names]
-            cache.delete_many(keys)
+        WikiPage.objects.clear_topic(self)
 
         return super(Topic, self).delete(*args, **kwargs)
 

--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -539,6 +539,14 @@ class PageManager(models.Manager):
             page.update_meta()
         return page
 
+    def clear_topic(self, topic):
+        """Unset the topic from all pages associated with it."""
+        pages = Page.objects.filter(topic=topic)
+        names = pages.values_list('name', flat=True)
+        keys = [u'wiki/page/{}'.format(n).lower() for n in names]
+        if pages.update(topic=None) > 0:
+            cache.delete_many(keys)
+
 
 class TextManager(models.Manager):
     """


### PR DESCRIPTION
Deleting forum topics would not reset the cache of wiki pages, if the topic was marked as a discussion for said wiki page. Until the cache is reset, such pages would trigger a `DoesNotExist` exception.

This commit ensures that cache keys for wiki pages are deleted when topics are deleted.
