### PR TITLE
Workarounded failing Jenkins-build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ node {
     sh '''rm -rf theme-ubuntuusers'''
 
     stage 'Build virtualenv'
-    sh '''virtualenv venv
+    sh '''virtualenv --no-download venv
     . ./venv/bin/activate
     # Workaround for pip, because it will hang forever when not updated and using the cache.
     pip install --upgrade pip --no-cache-dir


### PR DESCRIPTION
Fixes issue with virtualenv/pip when there is a slash in the the git branch-name
