### PR TITLE
HOTFIX: Check if a user is inactive before activating him

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -336,7 +336,7 @@ def activate(request, action='', username='', activation_key=''):
             messages.error(request, _(u'Your activation key is invalid.'))
         return HttpResponseRedirect(href('portal'))
     else:
-        if check_activation_key(user, activation_key):
+        if check_activation_key(user, activation_key) and user.is_inactive:
             user.status = User.STATUS_ACTIVE
             user.save()
             messages.success(request,


### PR DESCRIPTION
There was the issue, that a banned user could also use the activation
link to activate himself again.
