### PR TITLE
Jenkins optimization: Do not terminate on test failures and paralize database tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,19 +39,19 @@ node {
       cd .."""
     }
 
-    stage('Tests: mysql') {
-      sh '''. venv/bin/activate
-      python manage.py test --setting tests.settings.mysql --testrunner="xmlrunner.extra.djangotestrunner.XMLTestRunner" || true'''
-    }
+    stage('Tests') {
+      def test_databases = [ "mysql", "postgresql", "sqlite" ]
+      def test_runs = [:]
 
-    stage('Tests: postgresql') {
-      sh '''. venv/bin/activate
-      python manage.py test --setting tests.settings.postgresql --testrunner="xmlrunner.extra.djangotestrunner.XMLTestRunner" || true'''
-    }
+      for (int i = 0; i < test_databases.size(); i++) {
+        def current_test_database = test_databases[i]
+        test_runs["${current_test_database}"] = {
+          sh """. venv/bin/activate
+          python manage.py test --setting tests.settings.${current_test_database} --testrunner='xmlrunner.extra.djangotestrunner.XMLTestRunner' || true"""
+        }
+      }
 
-    stage('Tests: sqlite') {
-      sh '''. venv/bin/activate
-      python manage.py test --setting tests.settings.sqlite --testrunner="xmlrunner.extra.djangotestrunner.XMLTestRunner" || true'''
+      parallel test_runs
     }
 
     stage('Analyse tests') {


### PR DESCRIPTION
- The builds got canceled when tests failed. Now after a test failure the Jenkins will continue with the text examination like intended.
- The 3 different databases can be tested independent from each other to improve the performance.
