### PR TITLE
Add 'sqlparse' as a requirement for pip

### DIFF
--- a/extra/requirements/development.txt
+++ b/extra/requirements/development.txt
@@ -12,3 +12,4 @@ mock==1.3.0
 psycopg2==2.6.1
 responses==0.5.1
 Sphinx==1.3.6
+sqlparse==0.1.19


### PR DESCRIPTION
This is needed because a new version of it isn't compatable anymore. For
more information take a look on to:
http://stackoverflow.com/questions/38479063/django-debug-toolbar-breaking-on-admin-while-getting-sql-stats
