### PR TITLE
Delete unneccesary resend activation link method

### DIFF
--- a/inyoka/portal/urls.py
+++ b/inyoka/portal/urls.py
@@ -60,7 +60,6 @@ urlpatterns = [
     url(r'^inyoka/$', views.about_inyoka),
     url(r'^register/$', views.register),
     url(r'^(?P<action>activate|delete)/(?P<username>[^/]+)/(?P<activation_key>.*?)/$', views.activate),
-    url(r'^register/resend/(?P<username>[^/]+)/$', views.resend_activation_mail),
     url(r'^confirm/(?P<action>reactivate_user|set_new_email|reset_email)/$', views.confirm),
     url(r'^lost_password/$', views.lost_password),
     url(r'^lost_password/(?P<uidb36>[0-9A-Za-z]{1,13})/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$', views.set_new_password),

--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -335,21 +335,6 @@ def activate(request, action='', username='', activation_key=''):
             return HttpResponseRedirect(href('portal'))
 
 
-@does_not_exist_is_404
-def resend_activation_mail(request, username):
-    """Resend the activation mail if the user is not already activated."""
-    user = User.objects.get(username__iexact=username)
-
-    if not user.is_inactive:
-        messages.error(request,
-            _(u'The account “%(username)s” was already activated.') %
-            {'username': escape(user.username)})
-        return HttpResponseRedirect(href('portal'))
-    send_activation_mail(user)
-    messages.success(request, _(u'An email with the activation key was sent to you.'))
-    return HttpResponseRedirect(href('portal'))
-
-
 def lost_password(request):
     if request.user.is_authenticated():
         messages.error(request, _(u'You are already logged in.'))


### PR DESCRIPTION
There is an existing one that required admin privileges. Since
users already contact the admin-ml this is basically useless.

Fixes #580 

No further usage was found in the project so should be save to remove.
