### PR TITLE
Lexer: allow lists starting with arbitrary numbers

### DIFF
--- a/inyoka/markup/__init__.py
+++ b/inyoka/markup/__init__.py
@@ -748,10 +748,10 @@ class Parser(object):
             full = token.value.expandtabs()
             stripped = full.lstrip()
             indentation = len(full) - len(stripped)
-            return indentation, ('unordered', 'unordered', 'arabiczero',
-                               'arabic', 'alphalower', 'alphaupper',
-                               'romanlower', 'romanupper'
-                               )['*-01aAiI'.index(stripped[0])]
+            return indentation, (('unordered', 'unordered', 'arabiczero') +
+                                ('arabic', )*9 + ('alphalower', 'alphaupper',
+                                'romanlower', 'romanupper'
+                                ))['*-0123456789aAiI'.index(stripped[0])]
 
         indentation, list_type = check_item(stream.current)
         result = nodes.List(list_type)

--- a/inyoka/markup/lexer.py
+++ b/inyoka/markup/lexer.py
@@ -114,7 +114,7 @@ rules = {
         rule(r'^[ \t]+((?!::).*?)::\s+(?m)', bygroups('definition_term'),
              enter='definition'),
         rule(r'^\|\|(?m)', enter='table_row'),
-        rule(r'^[ \t]+(?:[*-]|[01aAiI]\.)\s*(?m)', enter='list_item'),
+        rule(r'^[ \t]+(?:[*-]|[0-9aAiI]+\.)\s*(?m)', enter='list_item'),
         rule(r'\{\{\|', enter='box'),
         rule(r'\{\{\{', enter='pre'),
         rule(r'^<{40}\s*$(?m)', enter='conflict'),

--- a/tests/apps/markup/test_lexer.py
+++ b/tests/apps/markup/test_lexer.py
@@ -231,6 +231,21 @@ class TestLexer(unittest.TestCase):
 
         expect('eof')
 
+    def test_list_2(self):
+        expect = lexer.tokenize(
+            ' * foo\n'
+            '  * foo\n'
+            ' 1. foo\n'
+            ' 10. foo'
+        ).expect
+
+        for x in xrange(4):
+            expect('list_item_begin')
+            expect('text', 'foo')
+            expect('list_item_end')
+
+        expect('eof')
+
     def test_quote(self):
         expect = lexer.tokenize(
             '> foo\n'


### PR DESCRIPTION
Allows this:

```
 1. foo
 2. bar
 42. lorem ipsum
```