### PR TITLE
Fixed #658: Do not hide the entire planet because of this permission

### DIFF
--- a/inyoka/planet/views.py
+++ b/inyoka/planet/views.py
@@ -54,7 +54,6 @@ blog_edit = generic.CreateUpdateView(model=Blog,
     permission_required='planet.change_blog')
 
 
-@permission_required('planet.view_blog', raise_exception=True)
 @templated('planet/index.html', modifier=context_modifier)
 def index(request, page=1):
     """


### PR DESCRIPTION
This permission hides only the access to grap the blogs list.
Before the feature branch this permission was granted also to annoymous.

Fixes #658