### PR TITLE
Only clear welcome Message field if we have an forum object. Fixes #662

### DIFF
--- a/inyoka/forum/views.py
+++ b/inyoka/forum/views.py
@@ -1807,7 +1807,7 @@ class ForumEditMixin(PermissionRequiredMixin):
     template_name = 'forum/forum_edit.html'
 
     def form_valid(self, form):
-        if 'welcome_title' in form.changed_data or 'welcome_text' in form.changed_data:
+        if self.object and ('welcome_title' in form.changed_data or 'welcome_text' in form.changed_data):
             self.object.clear_welcome()
         return super(ForumEditMixin, self).form_valid(form)
 


### PR DESCRIPTION
Just take a look at https://github.com/inyokaproject/inyoka/issues/662 to see the problem. We try to clean fields of non existend objects.