### PR TITLE
Fix escaped code markup

### DIFF
--- a/inyoka/markup/lexer.py
+++ b/inyoka/markup/lexer.py
@@ -210,7 +210,6 @@ rules = {
     ),
     'escaped_code': ruleset(
         rule('``', leave=1),
-        rule('`', enter='code')
     ),
     'code': ruleset(
         rule('`', leave=1),

--- a/tests/apps/markup/test_lexer.py
+++ b/tests/apps/markup/test_lexer.py
@@ -265,3 +265,10 @@ class TestLexer(unittest.TestCase):
     def test_basic_unicode_handling(self):
         expect = lexer.tokenize(u'some @¹“”¹unicod€ stuff'.encode('utf-8')).expect
         expect('text', u'some @¹“”¹unicod€ stuff')
+
+    def test_escaped_code(self):
+        expect = lexer.tokenize('``text`text``').expect
+        expect('escaped_code_begin')
+        expect('text', 'text`text')
+        expect('escaped_code_end')
+        expect('eof')


### PR DESCRIPTION
previously, this:

    ``text`text``

was rendered as this:

    <code class="notranslate">testse`aasd``</code>


now, this is:

    <code class="notranslate">testse`aasd</code>