### PR TITLE
Fix #663: Remove the referrer from the paste

### DIFF
--- a/inyoka/pastebin/migrations/0005_remove_entry_referrer.py
+++ b/inyoka/pastebin/migrations/0005_remove_entry_referrer.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pastebin', '0004_auto_20160703_0051'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='entry',
+            name='referrer',
+        ),
+    ]

--- a/inyoka/pastebin/models.py
+++ b/inyoka/pastebin/models.py
@@ -26,7 +26,6 @@ class Entry(models.Model):
     pub_date = models.DateTimeField(ugettext_lazy('Date'), db_index=True,
                                     default=datetime.utcnow)
     author = models.ForeignKey(User, verbose_name=ugettext_lazy('Author'))
-    referrer = models.TextField(ugettext_lazy('Referencing pages'), blank=True)
 
     class Meta:
         verbose_name = ugettext_lazy('Entry')
@@ -35,26 +34,6 @@ class Entry(models.Model):
         permissions = (
             ('view_entry', 'Can view Entry'),
         )
-
-    @property
-    def referrer_list(self):
-        return [x for x in self.referrer.splitlines() if x]
-
-    def add_referrer(self, referrer):
-        if is_safe_domain(referrer):
-            # make sure that the referrer isn't a pastebin url
-            netloc = urlparse(referrer)[1]
-            if ('.' + netloc).endswith(('.' + urlparse(href('pastebin'))[1])):
-                return False
-            if '?' in referrer:
-                referrer = referrer.split('?')[0]
-            r = self.referrer_list
-            if referrer in r:
-                return False
-            r.append(referrer)
-            self.referrer = u'\n'.join(sorted(r))
-            return True
-        return False
 
     def get_absolute_url(self, action='show'):
         return href(*{

--- a/inyoka/pastebin/views.py
+++ b/inyoka/pastebin/views.py
@@ -50,9 +50,6 @@ def display(request, entry_id):
     except Entry.DoesNotExist:
         return global_not_found(request, _(u'Paste number %(id)d could not be found')
                                   % {'id': int(entry_id)})
-    referrer = request.META.get('HTTP_REFERER')
-    if referrer and entry.add_referrer(referrer):
-        entry.save()
     return {
         'entry': entry,
         'page': 'browse'


### PR DESCRIPTION
This was done to avoid security issues because the references weren't
checked against the access rights of the viewer. (#663)

This also fixes #533