### PR TITLE
Docs: Added charset to create table directive

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -183,7 +183,7 @@ You need to add a database in MySQL:
 .. code-block:: console
 
     $ mysql -u root [-p]
-    mysql> create database ubuntuusers;
+    mysql> create database ubuntuusers CHARSET utf8 COLLATE utf8_general_ci;
     mysql> quit
 
 You only need to use the ``-p`` parameter if you have set a root password on


### PR DESCRIPTION
For example Arch changed the default charset with https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/mariadb&id=d191e6c8ccde2faf3e7ce6b0beb77d0e0f29afe4