### PR TITLE
Document how to clean a productive dump from user data

### DIFF
--- a/docs/clean_database.sql
+++ b/docs/clean_database.sql
@@ -1,0 +1,27 @@
+SET FOREIGN_KEY_CHECKS = 0;
+# Remove unused tabels
+DROP TABLE IF EXISTS celery_taskmeta;
+DROP TABLE IF EXISTS celery_tasksetmeta;
+DROP TABLE IF EXISTS django_openid_association;
+DROP TABLE IF EXISTS django_openid_nonce;
+DROP TABLE IF EXISTS djcelery_crontabschedule;
+DROP TABLE IF EXISTS djcelery_intervalschedule;
+DROP TABLE IF EXISTS djcelery_periodictask;
+DROP TABLE IF EXISTS djcelery_periodictasks;
+DROP TABLE IF EXISTS djcelery_taskstate;
+DROP TABLE IF EXISTS djcelery_workerstate;
+DROP TABLE IF EXISTS djkombu_message;
+DROP TABLE IF EXISTS djkombu_queue;
+DROP TABLE IF EXISTS south_migrationhistory;
+
+# Remove content from user sensetive tabels
+DELETE FROM portal_privatemessage;
+DELETE FROM portal_privatemessageentry;
+DELETE FROM portal_sessioninfo;
+DELETE FROM django_session;
+
+# Remove personal user informations
+UPDATE portal_user SET password = 'invalid';
+UPDATE portal_user SET email = CONCAT(username, '@ubuntuusers.invalid');
+UPDATE portal_user SET jabber = '', signature = '', location = '', gpgkey = '', website = '', launchpad = '';
+SET FOREIGN_KEY_CHECKS = 1;

--- a/docs/mysql-knowhow.rst
+++ b/docs/mysql-knowhow.rst
@@ -24,3 +24,11 @@ the disc. This can be done by importing the dump as follows:
   mysql -u root -p -f ubuntuusers
   SET sql_log_bin = 0;
   source /absolute/path/to/dump.sql;
+
+Clean a dump
+============
+
+Execute this commands to clean a dump from user sensetive informations:
+
+.. include:: clean_database.sql
+   :code: sql


### PR DESCRIPTION
For testing it is usefull to have a dump which contains more informations
than the demo database but we do not want to hand out sensetive
informations to developers.