### PR TITLE
Fixed #653 (finally)

### DIFF
--- a/inyoka/ikhaya/views.py
+++ b/inyoka/ikhaya/views.py
@@ -773,7 +773,7 @@ def suggestions_unsubscribe(request):
 def event_edit(request, pk=None):
     new = not pk
     if new and not request.user.has_perm('portal.add_event'):
-        raise AccessDeniedResponse()
+        return AccessDeniedResponse()
     event = Event.objects.get(id=pk) if not new else None
 
     if request.GET.get('copy_from', None):

--- a/inyoka/portal/forms.py
+++ b/inyoka/portal/forms.py
@@ -681,6 +681,7 @@ class GroupGlobalPermissionForm(forms.Form):
     PORTAL_FILTERED_PERMISSIONS = (
         'portal.delete_user',
         'portal.add_staticfile',
+        'portal.add_staticpage',
         'portal.delete_staticpage',
     )
     FORUM_FILTERED_PERMISSIONS = (


### PR DESCRIPTION
* Hide portal.add_staticpage permission
* Fixed traceback for add_event permission check