### PR TITLE
Update Babel and the transifex client to their latest versions

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -1,5 +1,5 @@
 --no-binary lxml,Pillow
-Babel==2.2.0
+Babel==2.4.0
 beautifulsoup4==4.4.1
 celery==3.1.23
 defusedxml==0.4.1
@@ -27,7 +27,7 @@ pyzmq==15.2.0
 raven==5.11.1
 requests==2.9.1
 SleekXMPP==1.3.1
-transifex-client==0.11
+transifex-client==0.12.4
 Werkzeug==0.11.4
 django-guardian==1.4.5
 icalendar==3.11.3


### PR DESCRIPTION
We also could think about why the transifex client is inside of the server requirements, because it isn't needed at runtime.