### PR TITLE
FIX: Normal user couldn't see any groups

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -435,12 +435,7 @@ def profile(request, username):
     """Show the user profile if the user is logged in."""
 
     user = User.objects.get(username__iexact=username)
-
-    if request.user.has_perm('portal.change_user'):
-        groups = user.groups.all()
-    else:
-        groups = ()
-
+    groups = user.groups.all()
     subscribed = Subscription.objects.user_subscribed(request.user, user)
 
     return {


### PR DESCRIPTION
Previously a regular user could see the public groups of a user and user
change permissions were only needed for private groups. Since all groups
are public now, the if isn't needed anymore.

Before the permission changes, the code looked like this: https://github.com/inyokaproject/inyoka/blame/8ba613009c2c0905ee043edf7addca0ab59c4c4f/inyoka/portal/views.py#L467