### PR TITLE
Implement a default ordering for Ikhaya Comments. Fixes #782

### DIFF
--- a/inyoka/ikhaya/migrations/0008_comment_ordering.py
+++ b/inyoka/ikhaya/migrations/0008_comment_ordering.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ikhaya', '0007_auto_20170117_1828'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='comment',
+            options={'ordering': ['id']},
+        ),
+    ]

--- a/inyoka/ikhaya/models.py
+++ b/inyoka/ikhaya/models.py
@@ -398,6 +398,9 @@ class Comment(models.Model):
     pub_date = models.DateTimeField()
     deleted = models.BooleanField(null=False, default=False)
 
+    class Meta:
+        ordering = ['id']
+
     def get_absolute_url(self, action='show'):
         if action in ['hide', 'restore', 'edit']:
             return href('ikhaya', 'comment', self.id, action)


### PR DESCRIPTION
MySQL orders by id (in most cases), but PostgreSQL has an more random
order. With this change we enforce the same order on every database
backend.

Ordering by id is the fastest way for an stable ordering.