### PR TITLE
Fixes #787: Add a default ordering for topics

### DIFF
--- a/inyoka/forum/migrations/0013_auto_20170501_1942.py
+++ b/inyoka/forum/migrations/0013_auto_20170501_1942.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('forum', '0012_django_permissions'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='topic',
+            options={'ordering': ['id'], 'verbose_name': 'Topic', 'verbose_name_plural': 'Topics', 'permissions': (('manage_reported_topic', 'Can manage reported Topics'),)},
+        ),
+    ]

--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -544,6 +544,7 @@ class Topic(models.Model):
         permissions = (
             ('manage_reported_topic', 'Can manage reported Topics'),
         )
+        ordering = ['id']
 
     def cached_forum(self):
         return Forum.objects.get(self.forum_id)


### PR DESCRIPTION
Topics also didn't had a default order, therefore they were now shown in
an other order in the reportslist.