### PR TITLE
Filter out Forum Topics without first/last_post. Fixes #755

### DIFF
--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -185,7 +185,11 @@ class TopicManager(models.Manager):
         related = ('author', 'last_post', 'last_post__author', 'first_post',
                    'first_post__author')
         order = ('-sticky', '-last_post__id')
-        return self.get_queryset().filter(pk__in=topic_ids) \
+        filter_by = { 'pk__in':topic_ids,
+                      'first_post__isnull':False,
+                      'last_post__isnull':False
+                    }
+        return self.get_queryset().filter(**filter_by) \
                    .select_related(*related).order_by(*order)
 
     def get_latest(self, forum_slug=None, allowed_forums=None, count=10):
@@ -205,7 +209,11 @@ class TopicManager(models.Manager):
 
         topic_ids = cache.get(key)
         if topic_ids is None:
-            query = Topic.objects.filter(hidden=False)
+            filter_by = { 'hidden':False,
+                          'first_post__isnull':False,
+                          'last_post__isnull':False
+                        }
+            query = Topic.objects.filter(**filter_by)
             if forum_slug:
                 query = query.filter(forum__id=forum.id)
             if allowed_forums:

--- a/inyoka/forum/views.py
+++ b/inyoka/forum/views.py
@@ -162,10 +162,7 @@ def forum(request, slug, page=1):
     last_post_ids = map(lambda f: f.last_post_id, subforums)
     last_post_map = Post.objects.last_post_map(last_post_ids)
 
-    qs = Topic.objects.prepare_for_overview(list(pagination.get_queryset()))
-
-    # FIXME: Filter topics with no last_post or first_post
-    topics = [topic for topic in qs if topic.first_post and topic.last_post]
+    topics = Topic.objects.prepare_for_overview(list(pagination.get_queryset()))
 
     if not request.user.has_perm('forum.moderate_forum', forum):
         topics = [topic for topic in topics if not topic.hidden]


### PR DESCRIPTION
Avoids some list magic in our forum view and move the filtering to the
right place (Model).