### PR TITLE
Fixes #801: Make hidden blog posts visible if you can hide a blog post

### DIFF
--- a/inyoka/planet/views.py
+++ b/inyoka/planet/views.py
@@ -61,7 +61,7 @@ def index(request, page=1):
     The page number is optional.
     """
     entries = Entry.objects.select_related('blog')
-    if not request.user.has_perm('planet.view_hidden_entry'):
+    if not request.user.has_perm('planet.hide_entry'):
         entries = entries.filter(hidden=False)
 
     pagination = Pagination(request, entries, page, 25, href('planet'))


### PR DESCRIPTION
The view permision for hidden posts actually does not exsist and therefore
cannot be granted.