### PR TITLE
Downgrade jinja2 to 2.8

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -12,7 +12,7 @@ dnspython==1.15.0
 feedparser==5.2.1
 gunicorn==19.6.0
 html5lib==1.0b8
-Jinja2==2.9.6
+Jinja2==2.8
 lxml==3.8.0
 MarkupSafe==1.0
 mysql-python==1.2.5


### PR DESCRIPTION
The update to 2.9 cause f.e. issues on a wiki-page like 'Welcome/45'
corresponding lines in the template: https://github.com/inyokaproject/theme-ubuntuusers/blob/staging/inyoka_theme_ubuntuusers/templates/wiki/page.html#L15-L22

seems to be https://github.com/pallets/jinja/issues/641