### PR TITLE
Remove portal_sessioninfo for performance reasons.

### DIFF
--- a/docs/clean_database.sql
+++ b/docs/clean_database.sql
@@ -17,7 +17,6 @@ DROP TABLE IF EXISTS south_migrationhistory;
 # Remove content from user sensetive tabels
 DELETE FROM portal_privatemessage;
 DELETE FROM portal_privatemessageentry;
-DELETE FROM portal_sessioninfo;
 DELETE FROM django_session;
 
 # Remove personal user informations

--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -282,10 +282,6 @@ CELERY_IMPORTS = [
 
 # Run tasks at specific time
 CELERYBEAT_SCHEDULE = {
-    'clean-sessions-every-5-minutes': {
-        'task': 'inyoka.portal.tasks.clean_sessions',
-        'schedule': timedelta(minutes=5),
-    },
     'check-for-new-session-record': {
         'task': 'inyoka.portal.tasks.check_for_user_record',
         'schedule': timedelta(minutes=5),

--- a/inyoka/portal/migrations/0025_delete_sessioninfo.py
+++ b/inyoka/portal/migrations/0025_delete_sessioninfo.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('portal', '0024_auto_20170429_1526'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='SessionInfo',
+        ),
+    ]

--- a/inyoka/portal/models.py
+++ b/inyoka/portal/models.py
@@ -72,23 +72,6 @@ class SubscriptionManager(ContentTypeManager):
                             .update(notified=0)
 
 
-class SessionInfo(models.Model):
-    """
-    A special class that holds session information.  Not every session
-    automatically has a session info.  Basically every user that is
-    active has a session info that is updated every request.  The
-    management functions for this model are in `inyoka.utils.sessions`.
-    """
-    key = models.CharField(max_length=200, unique=True, db_index=True)
-    last_change = models.DateTimeField(db_index=True)
-    subject_text = models.CharField(max_length=100, null=True)
-    subject_type = models.CharField(max_length=20)
-    subject_link = models.CharField(max_length=200, null=True)
-    action = models.CharField(max_length=500)
-    action_link = models.CharField(max_length=200, null=True)
-    category = models.CharField(max_length=200, null=True)
-
-
 PRIVMSG_FOLDERS_DATA = (
     (0, 'sent', ugettext_lazy(u'Send')),
     (1, 'inbox', ugettext_lazy(u'Inbox')),
@@ -322,7 +305,7 @@ class Subscription(models.Model):
         model = self.content_type.model
 
         if model == 'topic':
-            return user.has_perm('forum.view_forum',  self.content_object.forum)
+            return user.has_perm('forum.view_forum', self.content_object.forum)
         if model == 'forum':
             return user.has_perm('forum.view_forum', self.content_object)
         if model == 'page':


### PR DESCRIPTION
According to a analysis it did today portal_sessioninfo is the most
written table in our database. >50% of all write request on production
go to this table.

The only known reason for this table is the user record and information
about logged in users in a portal view. I moved this tasks and the
sessioninfos to redis, without changing the behavior.