### PR TITLE
Unified Logging

### DIFF
--- a/inyoka/planet/tasks.py
+++ b/inyoka/planet/tasks.py
@@ -13,7 +13,6 @@
     :copyright: (c) 2007-2017 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-import logging
 import re
 import socket
 # And further patch it so feedparser works :/
@@ -32,24 +31,15 @@ from django.utils.html import escape
 import inyoka  # noqa
 from inyoka.planet.models import Blog, Entry
 from inyoka.utils.html import cleanup_html
+from inyoka.utils.logger import logger
 
 make_parser = xml.sax.make_parser
 xml.sax.make_parser = lambda x: make_parser()
 # End XML patching.
 
-
-
-
-
-
-
-
 # set a default timeout. Otherwise fetching some feeds might cause the script
 # to block forever
 socket.setdefaulttimeout(20.0)
-
-# enable logging
-logger = logging.getLogger(__name__)
 
 HTML_MIMETYPES = frozenset(('text/html', 'application/xml+xhtml', 'application/xhtml+xml'))
 _par_re = re.compile(r'\n{2,}')
@@ -62,6 +52,7 @@ def nl2p(s):
 
 def dateutilDateHandler(aDateString):
     return dateutil_parse(aDateString).utctimetuple()
+
 
 feedparser.registerDateHandler(dateutilDateHandler)
 

--- a/inyoka/utils/notification.py
+++ b/inyoka/utils/notification.py
@@ -12,6 +12,7 @@ from django.conf import settings
 
 from inyoka.portal.models import Subscription
 from inyoka.utils.jabber import send as send_jabber
+from inyoka.utils.logger import logger
 from inyoka.utils.mail import send_mail
 from inyoka.utils.templating import render_template
 
@@ -93,5 +94,7 @@ def queue_notifications(request_user_id, template=None, subject=None, args=None,
 
     if callback is not None:
         subtask(callback).delay(list(notified_users))
+
+    logger.debug('Notified for {}: {}'.format(template, notified_users))
 
     return notified_users

--- a/inyoka/utils/spam.py
+++ b/inyoka/utils/spam.py
@@ -8,17 +8,13 @@
     :copyright: (c) 2015-2017 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-
-import logging
-
 import requests
 from django.conf import settings
 from django.contrib import messages
 from django.core.cache import cache
 from django.forms import ValidationError
 from django.utils.translation import ugettext_lazy as _
-
-logger = logging.getLogger('inyoka.antispam')
+from inyoka.utils.logger import logger
 
 
 def get_verify_key_url():


### PR DESCRIPTION
Currently we used two differen logging implementions, this unifies them to only one. As a benefit
we can use logger.warning() to raise something to sentry.

Also log already notified users in our notification subsystem.