### PR TITLE
It should not be possible to create Static Pages which only differ by case

### DIFF
--- a/inyoka/portal/forms.py
+++ b/inyoka/portal/forms.py
@@ -981,9 +981,15 @@ class WikiFeedSelectorForm(FeedSelectorForm):
 
 
 class EditStaticPageForm(forms.ModelForm):
-    def __init__(self, *args, **kwargs):
-        super(EditStaticPageForm, self).__init__(*args, **kwargs)
-        self.fields['key'].required = False
+
+    def clean_key(self):
+        key = self.cleaned_data.get('key')
+        if self.instance.key and self.instance.key != key:
+            raise forms.ValidationError(_(u'It is not allowed to change this key.'))
+        if StaticPage.objects.filter(key__iexact=key).exists():
+            raise forms.ValidationError(_(u'Another page with this name '
+                u'already exists. Please edit this page.'))
+        return key
 
     class Meta:
         model = StaticPage

--- a/inyoka/portal/urls.py
+++ b/inyoka/portal/urls.py
@@ -74,12 +74,13 @@ urlpatterns = [
     url(r'^styles/$', views.styles),
     # shortcuts
     url(r'^ikhaya/(\d+)/$', views.ikhaya_redirect),
-    # static pages
+    # static files
     url(r'^files/$', views.files),
     url(r'^files/(?P<page>\d+)/$', views.files),
     url(r'^files/new/$', views.file_edit),
     url(r'^files/(?P<file>.+)/edit/$', views.file_edit),
     url(r'^files/(?P<slug>.+)/delete/$', views.file_delete),
+    # static pages
     url(r'^pages/$', views.pages),
     url(r'^page/new/$', views.page_edit),
 ]


### PR DESCRIPTION
This fix also ensures that it is not possible to change the key (slug) of an static page, this
is an workaround until we are on Django 1.9 (disabled field support!).