### PR TITLE
Improved Slow Request Logging

### DIFF
--- a/inyoka/middlewares/common.py
+++ b/inyoka/middlewares/common.py
@@ -62,11 +62,19 @@ class CommonServicesMiddleware(HostsRequestMiddleware, CommonMiddleware):
                 and settings.DEBUG):
             response['Access-Control-Allow-Origin'] = '*'
 
-        # warn of slow requests
-        if int(request.watch.duration) > 5:
-            logger.warning(u'Slow Request', extra={
-                'request': request, 'url': request.build_absolute_uri()
-            })
+        request.watch.stop()
+        logger_extras = {
+            'request': request,
+            'url': request.build_absolute_uri(),
+            'duration': request.watch.duration,
+        }
+        duration = request.watch.duration
+        if duration < 5.0:
+            logger.debug(u'Request Duration', extra=logger_extras)
+        if duration >= 5.0 and duration < 10.0:
+            logger.info(u'Slow Request', extra=logger_extras)
+        if duration >= 10.0:
+            logger.warn(u'Very Slow Request', extra=logger_extras)
 
         local_manager.cleanup()
 


### PR DESCRIPTION
Currently we rely on "Slow Requests" are requests with a runtime >5 Seconds, this PR changes this
behavior, so we have 3 differen levels:
* Up to 5 Seconds: Only if debugging is enabled
* From 5 to 10 Seconds: If Log Leve is INFO and above
* Greater 10 Seconds: Logged as Warning in Sentry

Works only after merging #863