### PR TITLE
Fixed queue_notifications return Value for Celery.

### DIFF
--- a/inyoka/utils/notification.py
+++ b/inyoka/utils/notification.py
@@ -97,4 +97,4 @@ def queue_notifications(request_user_id, template=None, subject=None, args=None,
 
     logger.debug('Notified for {}: {}'.format(template, notified_users))
 
-    return notified_users
+    return list(notified_users)


### PR DESCRIPTION
Celery uses JSON to encode return values of Tasks, therefor we should
always return list() instead of set() to avoid EncodeErrors.