### PR TITLE
HOTFIX: Disable every ubuntu version notification

### DIFF
--- a/inyoka/forum/notifications.py
+++ b/inyoka/forum/notifications.py
@@ -63,9 +63,6 @@ def notify_forum_subscriptions(notified_users, request_user_id, data):
                 'content_type_id': ctype(Forum).pk,
                 'object_id': data.get('forum_id')
             },
-            callback=notify_ubuntu_version_subscriptions.subtask(
-                args=(request_user_id, data)
-            ),
             exclude={'user_id__in': notified_users},
         )
     finally:

--- a/inyoka/portal/models.py
+++ b/inyoka/portal/models.py
@@ -299,7 +299,7 @@ class Subscription(models.Model):
     def can_read(self):
         if self.content_type is None:
             # e.g ubuntu version
-            return True
+            return False
 
         user = self.user
         model = self.content_type.model


### PR DESCRIPTION
We had a bug, that to many users got notifications for topics which
they hadn't subscribed to and which they couldn't read. This disables the
version notifications so that we can enable the other ones.