### PR TITLE
Replaced time.time by datetime.time in our calendar. Fixes #899

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -1469,11 +1469,12 @@ def calendar_ical(request, slug):
         raise Http404()
 
     cal = iCal()
+    current_time = datetime.now().time()
 
-    start = datetime.combine(event.date, event.time or time())
+    start = datetime.combine(event.date, event.time or current_time)
 
     if event.enddate:
-        end = datetime.combine(event.enddate, event.endtime or time())
+        end = datetime.combine(event.enddate, event.endtime or current_time)
     else:
         end = start
 


### PR DESCRIPTION
Nothing more to say, fixes this Traceback:
```
TypeError: combine() argument 2 must be datetime.time, not float
  File "django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "inyoka/portal/views.py", line 1473, in calendar_ical
    start = datetime.combine(event.date, event.time or time())

TypeError: combine() argument 2 must be datetime.time, not float
```

Related to Issue #899 