### PR TITLE
Add basic .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig: http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,rst}]
+indent_style = space
+indent_size = 4
+
+[.jenkins/**]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
With a supported editor/IDE, {indention,charset,trailing whitespace}-issues should be a thing of the past.