### PR TITLE
WIP: Revert coverage dependency back to 4.4.1

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -5,7 +5,7 @@ def runTestOnDatabase(String database) {
   ${activate_venv}
   export COVERAGE_FILE=.coverage-${database}
   coverage run --branch manage.py test --setting tests.settings.${database} --testrunner='xmlrunner.extra.djangotestrunner.XMLTestRunner' || true
-  coverage xml
+  coverage xml -o coverage-${database}.xml
   """
 }
 
@@ -110,7 +110,7 @@ pipeline {
         step([$class: 'CoberturaPublisher',
               autoUpdateHealth: false,
               autoUpdateStability: false,
-              coberturaReportFile: 'coverage.xml',
+              coberturaReportFile: 'coverage*.xml',
               failUnhealthy: false,
               failUnstable: false,
               maxNumberOfBuilds: 0,


### PR DESCRIPTION
It looks like that 4.4.2 sometimes creates invalide XML files which can't be parsed from Jenkins