### PR TITLE
Add max_line_length to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 120
 
 [*.{py,rst}]
 indent_style = space


### PR DESCRIPTION
Seems not to be supported in every editor
https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length
However, IMO it's still beneficial, if it's supported.