### PR TITLE
Jenkins: Add timeout option and print timestamps

### DIFF
--- a/.jenkins/Jenkinsfile
+++ b/.jenkins/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
   options {
     buildDiscarder(logRotator(numToKeepStr: '2'))
     timeout(time: 30, unit: 'MINUTES')
+    timestamps()
   }
   stages {
     stage('Prepare build') {


### PR DESCRIPTION
- print timestamps when executing commands, so we can roughly see when which commands are executed and how long they take
- add timeout option so the pipeline gets cancelled when it runs for more than 30min