### PR TITLE
Post revisions: Order by date via DB

### DIFF
--- a/inyoka/forum/views.py
+++ b/inyoka/forum/views.py
@@ -1345,12 +1345,14 @@ def revisions(request, post_id):
     forum = topic.forum
     if not request.user.has_perm('forum.moderate_forum', forum):
         return HttpResponseRedirect(post.get_absolute_url())
-    revs = PostRevision.objects.filter(post=post).all()
+
+    revisions = PostRevision.objects.filter(post=post).order_by('-store_date')
+
     return {
         'post': post,
         'topic': topic,
         'forum': forum,
-        'revisions': reversed(revs)
+        'revisions': revisions
     }
 
 


### PR DESCRIPTION
Instead of reversing the objects from the DB with Python, we let the DB do the ordering. That should be still faster, even if there is no index for store_date. IMO the overhead for an index is not needed, as only moderators will notice that at all. (The current text of a post is always stored directly inside `Post`)

After the postgresql-migration the ordering could also break without this change.

-----
if someone wants to test further, some example posts with many, many revisions:

```
>>> for p in Post.objects.only('id').annotate(count_revisions=Count('revisions')).order_by('-count_revisions')[:5]:
...     print p.id, p.count_revisions
2533116 131
3005217 106
4040812 104
2844083 104
6094212 94
```
Mind the cache ;)