### PR TITLE
Parse the time in recentchanges localized

### DIFF
--- a/inyoka/utils/dates.py
+++ b/inyoka/utils/dates.py
@@ -39,6 +39,7 @@ naturalday = lambda value, arg='DATE_FORMAT': djnaturalday(value, arg)
 format_date = lambda value, arg='DATE_FORMAT': defaultfilters.date(value, arg)
 format_datetime = lambda value, arg='DATETIME_FORMAT': defaultfilters.date(_localtime(value), arg)
 format_time = lambda value, arg='TIME_FORMAT': defaultfilters.time(value, arg)
+format_timetz = lambda value, arg='TIME_FORMAT': defaultfilters.time(_localtime(value), arg)
 
 
 def group_by_day(entries, date_func=attrgetter('pub_date'),

--- a/inyoka/utils/templating.py
+++ b/inyoka/utils/templating.py
@@ -39,8 +39,8 @@ from inyoka.utils.dates import (
     format_date,
     format_datetime,
     format_time,
-    naturalday,
-)
+    format_timetz,
+    naturalday)
 from inyoka.utils.local import current_request
 from inyoka.utils.special_day import check_special_day
 from inyoka.utils.text import human_number
@@ -304,6 +304,7 @@ FILTERS = {
     'date': format_date,
     'datetime': format_datetime,
     'time': format_time,
+    'timetz': format_timetz,
 }
 
 # setup the template environment

--- a/inyoka/wiki/tasks.py
+++ b/inyoka/wiki/tasks.py
@@ -96,12 +96,16 @@ def update_recentchanges():
     recentchanges = OrderedDict()
     for revision in revisions:
         change_date = revision.change_date.date()
-        change_time = revision.change_date.time()
         page_name = revision.page.name
         username = revision.user.username if revision.user else None
         if change_date not in recentchanges:
             recentchanges[change_date] = OrderedDict()
         if revision.page.name not in recentchanges[change_date]:
             recentchanges[change_date][page_name] = []
-        recentchanges[change_date][page_name].append({'time': change_time, 'username': username, 'note': revision.note})
+        recentchanges[change_date][page_name].append(
+            {
+                'change_date': revision.change_date,
+                'username': username,
+                'note': revision.note
+            })
     cache.set('wiki/recentchanges', recentchanges)


### PR DESCRIPTION
The time was displayed in UTC and in a to detailed format.

The theme part for this change is inyokaproject/theme-ubuntuusers#255

Fixes #950
Fixes #951