### PR TITLE
Fix #960: Wiki page names for attachments might be weird-cased

### DIFF
--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -482,7 +482,7 @@ class PageManager(models.Manager):
         provided.  If the page does not exist or it doesn't have an attachment
         defined the return value will be `None`.
         """
-        attachments = Revision.objects.filter(page__name=page_name, deleted=False) \
+        attachments = Revision.objects.filter(page__name__iexact=page_name, deleted=False) \
                               .values_list('attachment__file')\
                               .annotate(Max('id')).order_by('-id')[:1]
         if attachments:


### PR DESCRIPTION
MySQL didn't care 'bout case sensitivity. PostgreSQL does.