### PR TITLE
Events: Only fetch the values needed from DB

### DIFF
--- a/inyoka/ikhaya/views.py
+++ b/inyoka/ikhaya/views.py
@@ -725,6 +725,7 @@ def events(request, show_all=False, invisible=False):
         events = Event.objects.filter(date__gt=date.today(), visible=True)
 
     events = events.select_related('author')
+    events = events.only('author__username', 'slug', 'name', 'date')
 
     sortable = Sortable(events, request.GET, '-date',
         columns=['name', 'date'])


### PR DESCRIPTION
This optimization should further reduce the loading time of the eventspage.

Added also a basic test, as it's very easy (also in the template) to reduce this optimization.