### PR TITLE
Dont display 404, if calendar suggestion submitted

### DIFF
--- a/inyoka/ikhaya/views.py
+++ b/inyoka/ikhaya/views.py
@@ -861,8 +861,7 @@ def event_suggest(request):
             messages.success(request,
                 _(u'The event has been saved. A team member will review it '
                   u'soon.'))
-            event = Event.objects.get(id=event.id)  # get truncated slug
-            return HttpResponseRedirect(url_for(event))
+            return HttpResponseRedirect(href('portal', 'calendar'))
     else:
         form = NewEventForm()
 


### PR DESCRIPTION
Instead just redirect to the form again and display the message.

We could redirect to the hidden suggestion, if the user has the needed permissions.
However, those team members have an own view to create an calendar entry that
skips the review process completely.