### PR TITLE
Removed get_filename

### DIFF
--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -31,6 +31,7 @@ from django.utils.encoding import DjangoUnicodeDecodeError, force_unicode
 from django.utils.html import escape, format_html
 from django.utils.translation import ugettext as _
 from django.utils.translation import pgettext, ugettext_lazy
+from werkzeug.utils import secure_filename
 
 from inyoka.forum.constants import (
     CACHE_PAGES_COUNT,
@@ -49,7 +50,6 @@ from inyoka.utils.database import (
 )
 from inyoka.utils.dates import timedelta_to_seconds
 from inyoka.utils.decorators import deferred
-from inyoka.utils.files import get_filename
 from inyoka.utils.highlight import highlight_code
 from inyoka.utils.imaging import get_thumbnail
 from inyoka.utils.local import current_request
@@ -1171,7 +1171,7 @@ class Attachment(models.Model):
                 Specifies whether other attachments for the same post should
                 be overwritten if they have the same name.
         """
-        name = get_filename(name, uploaded_file)
+        name = secure_filename(name)
         # check whether an attachment with the same name already exists
         existing = filter(lambda a: a.name == name, attachments)
         exists = bool(existing)
@@ -1218,7 +1218,7 @@ class Attachment(models.Model):
         base_path = datetime.utcnow().strftime('forum/attachments/%S/%W')
 
         for attachment in attachments:
-            new_name = get_filename('%d-%s' % (post.pk, attachment.name))
+            new_name = secure_filename('%d-%s' % (post.pk, attachment.name))
             new_name = path.join(base_path, new_name)
 
             storage = attachment.file.storage

--- a/inyoka/utils/files.py
+++ b/inyoka/utils/files.py
@@ -12,14 +12,6 @@ import itertools
 import os.path
 
 from django.core.files.storage import FileSystemStorage
-from werkzeug import utils
-
-
-def get_filename(filename, file=None):
-    """
-    Returns a save filename (CAUTION: strips path components!).
-    """
-    return utils.secure_filename(filename) or 'Noname'
 
 
 class MaxLengthStorageMixin(object):

--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -94,6 +94,7 @@ from django.utils.html import escape
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
 from werkzeug import cached_property
+from werkzeug.utils import secure_filename
 
 from inyoka import default_settings, markup
 from inyoka.markup import nodes, templates
@@ -102,7 +103,6 @@ from inyoka.utils.database import InyokaMarkupField
 from inyoka.utils.dates import datetime_to_timezone, format_datetime
 from inyoka.utils.decorators import deferred
 from inyoka.utils.diff3 import generate_udiff, get_close_matches, prepare_udiff
-from inyoka.utils.files import get_filename
 from inyoka.utils.highlight import highlight_code
 from inyoka.utils.html import striptags
 from inyoka.utils.local import local as local_cache
@@ -561,7 +561,7 @@ class PageManager(models.Manager):
             note = _(u'Created')
         if attachment is not None:
             att = Attachment()
-            attachment_filename = get_filename(attachment_filename, attachment)
+            attachment_filename = secure_filename(attachment_filename)
             att.file.save(attachment_filename, attachment)
             att.save()
             attachment = att
@@ -1047,7 +1047,7 @@ class Page(models.Model):
             attachment = rev and rev.attachment or None
         elif attachment is not None:
             att = Attachment()
-            attachment_filename = get_filename(attachment_filename, attachment)
+            attachment_filename = secure_filename(attachment_filename)
             att.file.save(attachment_filename, attachment)
             att.save()
             attachment = att


### PR DESCRIPTION
We used these in the past, now its just a wrapper for werkzeug, so we can
use this instead.