### PR TITLE
Upgrade requests to version 2.20.0

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -28,7 +28,7 @@ python-magic==0.4.13
 pytz==2017.3
 pyzmq==16.0.3
 raven==6.3.0
-requests==2.18.4
+requests==2.20.0
 SleekXMPP==1.3.3
 transifex-client==0.12.5
 Werkzeug==0.12.2


### PR DESCRIPTION
This version is not affected by https://nvd.nist.gov/vuln/detail/CVE-2018-18074

The PR is against master, so the changes can be deployed independent of new (untested) features on staging.