### PR TITLE
Pin redis to 2.10.6

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -28,6 +28,7 @@ python-magic==0.4.13
 pytz==2017.3
 pyzmq==16.0.3
 raven==6.3.0
+redis==2.10.6 # django-redis requires redis>=2.10, but redis 3.x is incompatible with django-redis==4.4.4
 requests==2.20.0
 SleekXMPP==1.3.3
 transifex-client==0.12.5


### PR DESCRIPTION
As django-redis 4.4. is incompatible with the newer versions 3.x of redis.

See https://sentry.ubuntu-eu.org/ubuntuusers/staging/issues/831/, https://github.com/niwinz/django-redis/issues/342

The traceback is `DataError: Invalid input of type: 'CacheKey'. Convert to a byte, string or number first.` and occurs when visiting an page and also for some celery tasks.

This can be also easily tested locally, if you remove the current virtualenv completely and install it from scratch again.

That's the reason why http://staging.inyokaproject.org/ currently only returns Internal Server Error.