### PR TITLE
Pin SleekXMPP to 1.3.2

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -31,6 +31,6 @@ pyzmq==16.0.3
 raven==6.3.0
 redis==2.10.6 # django-redis requires redis>=2.10, but redis 3.x is incompatible with django-redis==4.4.4
 requests==2.20.0
-SleekXMPP==1.3.3
+SleekXMPP==1.3.2 # 1.3.3 breaks, see https://github.com/fritzy/SleekXMPP/issues/461
 transifex-client==0.12.5
 Werkzeug==0.12.2


### PR DESCRIPTION
1.3.3 is broken as of https://github.com/fritzy/SleekXMPP/issues/461. Someone seems to have forget to adapt the requirements after the first deployment in 2017 of https://github.com/inyokaproject/inyoka/commit/7e9e016e9c41f8374831e2a501c1b1a0b8168bc8.

Fore reference the exception is

```
ValueError

time data '190530023040Z' does not match format '%Y%m%d%H%M%SZ'
```