### PR TITLE
Update werkzeug to version 0.15.5

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -33,4 +33,4 @@ redis==2.10.6 # django-redis requires redis>=2.10, but redis 3.x is incompatible
 requests==2.20.0
 SleekXMPP==1.3.2 # 1.3.3 breaks, see https://github.com/fritzy/SleekXMPP/issues/461
 transifex-client==0.12.5
-Werkzeug==0.12.2
+Werkzeug==0.15.5


### PR DESCRIPTION
According to https://nvd.nist.gov/vuln/detail/CVE-2019-14806 werkzeug
before version 0.15.3 has a CVE inside docker.

I just tested quickly, whether the atom feeds for wiki article logs are still generated.

Pragmatically, i would suggest to delay a merge after the deployment, as we do not use docker on production and thus are not affected.