### PR TITLE
Update jinja to 2.10.1

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -15,7 +15,7 @@ feedparser==5.2.1
 gunicorn==19.7.1
 html5lib==1.0b8
 icalendar==4.0.0
-Jinja2==2.10
+Jinja2==2.10.1
 kombu==4.3.0
 lxml==4.1.1
 MarkupSafe==1.0


### PR DESCRIPTION
Contains a security bug → https://github.com/pallets/jinja/blob/master/CHANGES.rst#version-2101. Even if we do not use the `SandboxedEnvironment`, it should be fine to update.