### PR TITLE
Add loading="lazy" for all images in markup

### DIFF
--- a/inyoka/markup/nodes.py
+++ b/inyoka/markup/nodes.py
@@ -319,7 +319,7 @@ class Image(Node):
     def prepare_html(self):
         yield build_html_tag(u'img', src=self.href, alt=self.alt, id=self.id,
                              class_=self.class_, style=self.style,
-                             title=self.title)
+                             title=self.title, loading='lazy')
 
     def __setstate__(self, dict):
         self.__dict__ = dict

--- a/tests/apps/markup/test_macros.py
+++ b/tests/apps/markup/test_macros.py
@@ -23,7 +23,7 @@ class TestMacros(unittest.TestCase):
             format='html',
         )
 
-        result = '<a href="invalid-url" class="crosslink"><img alt="Bildname" class="image-default" /></a>'
+        result = '<a href="invalid-url" class="crosslink"><img loading="lazy" class="image-default" alt="Bildname" /></a>'
         self.assertIn(result, html)
 
     def test_toc_indention_ticket_688(self):


### PR DESCRIPTION
This has the potential to save bandwith and speedup page loading.
See f.e. https://addyosmani.com/blog/lazy-loading/ or
https://github.com/scott-little/lazyload for more information.

According to https://caniuse.com/#feat=loading-lazy-attr only
Chrome-based browsers support it at the moment. Nevertheless, that's
60% of all users globally. For other browsers the experience will be just
'as is' currently. IMO no hacky polyfill is needed.