### PR TITLE
jenkins/deploy: Allow two deployments of same PR

### DIFF
--- a/.jenkins/deploy.groovy
+++ b/.jenkins/deploy.groovy
@@ -31,7 +31,7 @@ pipeline {
         cd /srv/local/ubuntuusers/${params.DEPLOY_SITE}/theme
         if [ -n "${params.THEME_PR_ID}" ]
         then
-            git fetch origin pull/${params.THEME_PR_ID}/head:pr-${params.THEME_PR_ID}
+            git fetch --force origin pull/${params.THEME_PR_ID}/head:pr-${params.THEME_PR_ID}
             git checkout pr-${params.THEME_PR_ID}
         else
             git checkout ${params.DEPLOY_SITE}


### PR DESCRIPTION
If a PR-branch was deployed two times in a row, the second deployment
will fail with the following error:
```
git fetch origin pull/323/head:pr-323
fatal: Refusing to fetch into current branch refs/heads/pr-323 of non-bare repository
```
A workaround is to deploy staging (or another PR) and then the updated
PR.

Thus, --force is added to allow two consecutive deployments of the same
PR (see manpage of git-fetch).