### PR TITLE
Bump pygments to 2.5.2

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -23,7 +23,7 @@ Pillow==6.2.2
 psycopg2==2.7.3.2
 pyasn1_modules==0.1.5
 pyasn1==0.3.7
-Pygments==2.2.0
+Pygments==2.5.2
 python-dateutil==2.6.1
 python-magic==0.4.13
 pytz==2017.3


### PR DESCRIPTION
Fixes #581  according to https://github.com/pygments/pygments/releases/tag/2.4.0. Locally, i could also visit the mentioned posts without a timeout.

Pygments >2.6 is only support on Python 3 officially, seee
https://github.com/pygments/pygments/releases/tag/2.6.1