### PR TITLE
Remove jsi18n-url

### DIFF
--- a/inyoka/portal/urls.py
+++ b/inyoka/portal/urls.py
@@ -10,7 +10,6 @@
 """
 from django.conf import settings
 from django.conf.urls import include, url
-from django.views.i18n import javascript_catalog
 
 from . import views
 
@@ -84,16 +83,6 @@ urlpatterns = [
     url(r'^pages/$', views.pages),
     url(r'^page/new/$', views.page_edit),
 ]
-
-
-js_info_dict = {
-    'packages': ('inyoka.portal', 'inyoka.wiki', 'inyoka.pastebin',
-                 'inyoka.ikhaya', 'inyoka.planet', 'inyoka.forum'),
-}
-
-urlpatterns.append(
-    url(r'jsi18n/$', javascript_catalog, js_info_dict)
-)
 
 urlpatterns.extend([
     url(r'^([^/]+)/$', views.static_page),

--- a/inyoka/utils/sessions.py
+++ b/inyoka/utils/sessions.py
@@ -26,10 +26,9 @@ SESSION_DELTA = 300
 def set_session_info(request):
     """Set the session info."""
 
-    # Prevent extra queries for markup.css and jsi18n since they are loaded
-    # with every request, in development this also prevents extra queries for
-    # static files. In production these files are served by another server.
-    if request.path in ('/markup.css/', '/jsi18n/') or request.subdomain in ('static', 'media'):
+    # Prevent extra queries in development for static files. In
+    # production these files are served by another server.
+    if request.subdomain in ('static', 'media'):
         return
 
     # if the session is new we don't add an entry.  It could be that


### PR DESCRIPTION
The javascript_catalog function-view is depcrated since Django 1.10 and removed with 2.0 https://docs.djangoproject.com/en/3.0/releases/2.0/#features-removed-in-2-0

Furthermore, it is not used in the frontend (`ag 'pluralidx|gettext|ngettext|gettext_noop|pgettext|npgettext|interpolate|get_format'` did find nothing in the theme) and also fetched on *every request* (no caching…).

So i decided to drop this completly. If we need it, it can be readded with the new class following the django docs.