### PR TITLE
Remove USE_ETAGS

### DIFF
--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -120,9 +120,6 @@ INYOKA_INTERWIKI_CSS_PATH = join(MEDIA_ROOT, 'linkmap/linkmap-{hash}.css')
 # inyoka should deliver the statics
 INYOKA_HOST_STATICS = False
 
-# use etags
-USE_ETAGS = True
-
 # maximal number of tags shown in the tag cloud
 TAGCLOUD_SIZE = 100
 


### PR DESCRIPTION
With Django 1.11 USE_ETAGS setting is deprecated
https://docs.djangoproject.com/en/3.0/releases/1.11/

and with Django 2.1 removed
https://docs.djangoproject.com/en/3.0/releases/2.1/#features-removed-in-2-1

Nevertheless, ConditionalGetMiddleware is activated which should set etags.