### PR TITLE
Bump django-hosts to 3.0

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -6,7 +6,7 @@ certifi==2017.11.5
 defusedxml==0.5.0
 django-filter==1.0.4
 django-guardian==1.4.9
-django-hosts==2.0
+django-hosts==3.0
 django-redis==4.11.0
 Django==1.11.29
 dnspython==1.15.0


### PR DESCRIPTION
So it is compatible with Django 2.0. django-hosts 4.0 does not support Django 1.11.
see https://github.com/jazzband/django-hosts/blob/master/docs/changelog.rst