### PR TITLE
Add `on_delete=models.CASCADE` to all `ForeignKey` and `OneToOneField`

### DIFF
--- a/inyoka/forum/migrations/0002_auto_20151016_1603.py
+++ b/inyoka/forum/migrations/0002_auto_20151016_1603.py
@@ -54,25 +54,25 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='privilege',
             name='forum',
-            field=models.ForeignKey(to='forum.Forum'),
+            field=models.ForeignKey(to='forum.Forum', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='privilege',
             name='group',
-            field=models.ForeignKey(to='portal.Group', null=True),
+            field=models.ForeignKey(to='portal.Group', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='privilege',
             name='user',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='postrevision',
             name='post',
-            field=models.ForeignKey(related_name='revisions', to='forum.Post'),
+            field=models.ForeignKey(related_name='revisions', to='forum.Post', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -90,25 +90,25 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='pollvote',
             name='poll',
-            field=models.ForeignKey(related_name='votings', to='forum.Poll'),
+            field=models.ForeignKey(related_name='votings', to='forum.Poll', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='pollvote',
             name='voter',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='polloption',
             name='poll',
-            field=models.ForeignKey(related_name='options', to='forum.Poll'),
+            field=models.ForeignKey(related_name='options', to='forum.Poll', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='poll',
             name='topic',
-            field=models.ForeignKey(related_name='polls', to='forum.Topic', null=True),
+            field=models.ForeignKey(related_name='polls', to='forum.Topic', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -132,7 +132,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='attachment',
             name='post',
-            field=models.ForeignKey(related_name='attachments', to='forum.Post', null=True),
+            field=models.ForeignKey(related_name='attachments', to='forum.Post', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/inyoka/forum/migrations/0011_auto_20160702_1801.py
+++ b/inyoka/forum/migrations/0011_auto_20160702_1801.py
@@ -20,6 +20,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='privilege',
             name='group',
-            field=models.ForeignKey(to='auth.Group', null=True),
+            field=models.ForeignKey(to='auth.Group', null=True, on_delete=models.CASCADE),
         ),
     ]

--- a/inyoka/forum/models.py
+++ b/inyoka/forum/models.py
@@ -740,7 +740,7 @@ class PostRevision(models.Model):
 
     text = InyokaMarkupField(application='forum')
     store_date = models.DateTimeField(default=datetime.utcnow)
-    post = models.ForeignKey('forum.Post', related_name='revisions')
+    post = models.ForeignKey('forum.Post', related_name='revisions', on_delete=models.CASCADE)
 
     def get_absolute_url(self, action='restore'):
         return href('forum', 'revision', self.id, 'restore')
@@ -1155,7 +1155,7 @@ class Attachment(models.Model):
     comment = models.TextField(null=True, blank=True)
     mimetype = models.CharField(max_length=100, null=True)
 
-    post = models.ForeignKey(Post, null=True, related_name='attachments')
+    post = models.ForeignKey(Post, null=True, related_name='attachments', on_delete=models.CASCADE)
 
     @staticmethod
     def create(name, uploaded_file, mime, attachments, override=False, **kwargs):
@@ -1342,7 +1342,7 @@ class Attachment(models.Model):
 
 
 class PollOption(models.Model):
-    poll = models.ForeignKey('forum.Poll', related_name='options')
+    poll = models.ForeignKey('forum.Poll', related_name='options', on_delete=models.CASCADE)
     name = models.CharField(max_length=250)
     votes = models.IntegerField(default=0)
 
@@ -1355,8 +1355,8 @@ class PollOption(models.Model):
 
 
 class PollVote(models.Model):
-    voter = models.ForeignKey(User)
-    poll = models.ForeignKey('forum.Poll', related_name='votings')
+    voter = models.ForeignKey(User, on_delete=models.CASCADE)
+    poll = models.ForeignKey('forum.Poll', related_name='votings', on_delete=models.CASCADE)
 
     class Meta:
         db_table = 'forum_voter'
@@ -1368,7 +1368,7 @@ class Poll(models.Model):
     end_time = models.DateTimeField(null=True)
     multiple_votes = models.BooleanField(default=False)
 
-    topic = models.ForeignKey(Topic, null=True, db_index=True, related_name='polls')
+    topic = models.ForeignKey(Topic, null=True, db_index=True, related_name='polls', on_delete=models.CASCADE)
 
     @deferred
     def votes(self):

--- a/inyoka/ikhaya/migrations/0002_auto_20151016_1603.py
+++ b/inyoka/ikhaya/migrations/0002_auto_20151016_1603.py
@@ -18,37 +18,37 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='suggestion',
             name='author',
-            field=models.ForeignKey(related_name='suggestion_set', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(related_name='suggestion_set', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='suggestion',
             name='owner',
-            field=models.ForeignKey(related_name='owned_suggestion_set', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(related_name='owned_suggestion_set', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='report',
             name='article',
-            field=models.ForeignKey(to='ikhaya.Article', null=True),
+            field=models.ForeignKey(to='ikhaya.Article', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='report',
             name='author',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='comment',
             name='article',
-            field=models.ForeignKey(to='ikhaya.Article', null=True),
+            field=models.ForeignKey(to='ikhaya.Article', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='comment',
             name='author',
-            field=models.ForeignKey(to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='article',
             name='author',
-            field=models.ForeignKey(related_name='article_set', verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(related_name='article_set', verbose_name='Author', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/inyoka/ikhaya/models.py
+++ b/inyoka/ikhaya/models.py
@@ -198,7 +198,7 @@ class Article(models.Model, LockableObject):
     updated = models.DateTimeField(ugettext_lazy('Last change'), blank=True,
                 null=True, db_index=True)
     author = models.ForeignKey(User, related_name='article_set',
-                               verbose_name=ugettext_lazy('Author'))
+                               verbose_name=ugettext_lazy('Author'), on_delete=models.CASCADE)
     subject = models.CharField(ugettext_lazy('Headline'), max_length=180)
     category = models.ForeignKey(Category, verbose_name=ugettext_lazy('Category'),
                                  on_delete=models.PROTECT)
@@ -344,9 +344,9 @@ class Article(models.Model, LockableObject):
 
 
 class Report(models.Model):
-    article = models.ForeignKey(Article, null=True)
+    article = models.ForeignKey(Article, null=True, on_delete=models.CASCADE)
     text = InyokaMarkupField(application='ikhaya')
-    author = models.ForeignKey(User)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
     pub_date = models.DateTimeField()
     deleted = models.BooleanField(null=False, default=False)
     solved = models.BooleanField(null=False, default=False)
@@ -367,7 +367,7 @@ class Suggestion(models.Model):
 
     objects = SuggestionManager()
 
-    author = models.ForeignKey(User, related_name='suggestion_set')
+    author = models.ForeignKey(User, related_name='suggestion_set', on_delete=models.CASCADE)
     pub_date = models.DateTimeField('Datum', default=datetime.utcnow)
     title = models.CharField(ugettext_lazy('Title'), max_length=100)
     text = InyokaMarkupField(verbose_name=ugettext_lazy('Text'), application='ikhaya')
@@ -378,7 +378,7 @@ class Suggestion(models.Model):
         default='',
         application='ikhaya')
     owner = models.ForeignKey(User, related_name='owned_suggestion_set',
-                              null=True, blank=True)
+                              null=True, blank=True, on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = ugettext_lazy('Article suggestion')
@@ -392,9 +392,9 @@ class Comment(models.Model):
 
     objects = CommentManager()
 
-    article = models.ForeignKey(Article, null=True)
+    article = models.ForeignKey(Article, null=True, on_delete=models.CASCADE)
     text = InyokaMarkupField(application='ikhaya')
-    author = models.ForeignKey(User)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
     pub_date = models.DateTimeField()
     deleted = models.BooleanField(null=False, default=False)
 
@@ -429,7 +429,7 @@ class Event(models.Model):
     enddate = models.DateField(blank=True, null=True)  # None
     endtime = models.TimeField(blank=True, null=True)  # None -> whole day
     description = InyokaMarkupField(blank=True, application='ikhaya')
-    author = models.ForeignKey(User)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
     location = models.CharField(max_length=128, blank=True)
     location_town = models.CharField(max_length=56, blank=True)
     location_lat = models.FloatField(ugettext_lazy('Degree of latitude'),

--- a/inyoka/pastebin/migrations/0002_entry_author.py
+++ b/inyoka/pastebin/migrations/0002_entry_author.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='entry',
             name='author',
-            field=models.ForeignKey(verbose_name='Author', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(verbose_name='Author', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/inyoka/pastebin/models.py
+++ b/inyoka/pastebin/models.py
@@ -24,7 +24,7 @@ class Entry(models.Model):
     code = PygmentsField(application='pastebin')
     pub_date = models.DateTimeField(ugettext_lazy('Date'), db_index=True,
                                     default=datetime.utcnow)
-    author = models.ForeignKey(User, verbose_name=ugettext_lazy('Author'))
+    author = models.ForeignKey(User, verbose_name=ugettext_lazy('Author'), on_delete=models.CASCADE)
 
     class Meta:
         verbose_name = ugettext_lazy('Entry')

--- a/inyoka/planet/migrations/0001_initial.py
+++ b/inyoka/planet/migrations/0001_initial.py
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
                 ('author', models.CharField(max_length=50)),
                 ('author_homepage', models.URLField(null=True, blank=True)),
                 ('hidden', models.BooleanField(default=False)),
-                ('blog', models.ForeignKey(to='planet.Blog')),
+                ('blog', models.ForeignKey(to='planet.Blog', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('-pub_date',),

--- a/inyoka/planet/migrations/0002_auto_20151016_1603.py
+++ b/inyoka/planet/migrations/0002_auto_20151016_1603.py
@@ -16,13 +16,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='entry',
             name='hidden_by',
-            field=models.ForeignKey(related_name='hidden_planet_posts', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(related_name='hidden_planet_posts', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='blog',
             name='user',
-            field=models.ForeignKey(verbose_name='User', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(verbose_name='User', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/inyoka/planet/models.py
+++ b/inyoka/planet/models.py
@@ -36,7 +36,7 @@ class Blog(models.Model):
     blog_url = models.URLField(ugettext_lazy('URL of the blog'))
     feed_url = models.URLField(ugettext_lazy('URL of the feed'))
     user = models.ForeignKey(User, verbose_name=ugettext_lazy('User'),
-                             blank=True, null=True)
+                             blank=True, null=True, on_delete=models.CASCADE)
     icon = models.ImageField(ugettext_lazy('Icon'), upload_to='planet/icons', blank=True)
     last_sync = models.DateTimeField(blank=True, null=True)
     active = models.BooleanField(ugettext_lazy('Index the blog'), default=True)
@@ -74,7 +74,7 @@ class Blog(models.Model):
 
 class Entry(models.Model):
     objects = EntryManager()
-    blog = models.ForeignKey(Blog)
+    blog = models.ForeignKey(Blog, on_delete=models.CASCADE)
     guid = models.CharField(max_length=200, unique=True, db_index=True)
     title = models.CharField(max_length=140)
     url = models.URLField()
@@ -85,7 +85,7 @@ class Entry(models.Model):
     author_homepage = models.URLField(blank=True, null=True)
     hidden = models.BooleanField(default=False)
     hidden_by = models.ForeignKey(User, blank=True, null=True,
-                                  related_name='hidden_planet_posts')
+                                  related_name='hidden_planet_posts', on_delete=models.CASCADE)
 
     def __str__(self):
         return '%s / %s' % (

--- a/inyoka/portal/migrations/0001_initial.py
+++ b/inyoka/portal/migrations/0001_initial.py
@@ -78,7 +78,7 @@ class Migration(migrations.Migration):
                 ('location_lat', models.FloatField(null=True, verbose_name='Degree of latitude', blank=True)),
                 ('location_long', models.FloatField(null=True, verbose_name='Degree of longitude', blank=True)),
                 ('visible', models.BooleanField(default=False)),
-                ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'db_table': 'portal_event',
@@ -107,7 +107,7 @@ class Migration(migrations.Migration):
                 ('subject', models.CharField(max_length=255, verbose_name='Title')),
                 ('pub_date', models.DateTimeField(verbose_name='Date')),
                 ('text', inyoka.utils.database.InyokaMarkupField(simplify=False, verbose_name='Text', force_existing=False)),
-                ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('author', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ('-pub_date',),
@@ -120,8 +120,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('read', models.BooleanField(default=False, verbose_name='Read')),
                 ('folder', models.SmallIntegerField(null=True, verbose_name='Folder', choices=[(0, 'sent'), (1, 'inbox'), (2, 'trash'), (3, 'archive')])),
-                ('message', models.ForeignKey(to='portal.PrivateMessage')),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('message', models.ForeignKey(to='portal.PrivateMessage', on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -189,8 +189,8 @@ class Migration(migrations.Migration):
                 ('notified', models.BooleanField(default=False, verbose_name='User was already notified')),
                 ('ubuntu_version', models.CharField(max_length=5, null=True)),
                 ('object_id', models.PositiveIntegerField(null=True, db_index=True)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType', null=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', null=True, on_delete=models.CASCADE)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -202,7 +202,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('content', inyoka.utils.database.InyokaMarkupField(simplify=False, force_existing=False)),
                 ('content_rendered_old', models.TextField(db_column='content_rendered')),
-                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -215,7 +215,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='user',
             name='_primary_group',
-            field=models.ForeignKey(related_name='primary_users_set', db_column='primary_group_id', blank=True, to='portal.Group', null=True),
+            field=models.ForeignKey(related_name='primary_users_set', db_column='primary_group_id', blank=True, to='portal.Group', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(

--- a/inyoka/portal/models.py
+++ b/inyoka/portal/models.py
@@ -95,7 +95,7 @@ class PrivateMessage(models.Model):
     Private messages allow users to communicate with each other privately.
     This model represent one of these messages.
     """
-    author = models.ForeignKey(User)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
     subject = models.CharField(ugettext_lazy('Title'), max_length=255)
     pub_date = models.DateTimeField(ugettext_lazy('Date'))
     text = InyokaMarkupField(verbose_name=ugettext_lazy('Text'), application='portal')
@@ -144,8 +144,8 @@ class PrivateMessageEntry(models.Model):
     message.  This entry can be moved between folders and stores the
     read status flag.
     """
-    message = models.ForeignKey('PrivateMessage')
-    user = models.ForeignKey(User)
+    message = models.ForeignKey('PrivateMessage', on_delete=models.CASCADE)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
     read = models.BooleanField(ugettext_lazy('Read'), default=False)
     folder = models.SmallIntegerField(ugettext_lazy('Folder'),
         null=True,
@@ -286,13 +286,13 @@ class StaticFile(models.Model):
 
 class Subscription(models.Model):
     objects = SubscriptionManager()
-    user = models.ForeignKey(User)
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
     notified = models.BooleanField(
         ugettext_lazy('User was already notified'),
         default=False)
     ubuntu_version = models.CharField(max_length=5, null=True)
 
-    content_type = models.ForeignKey(ContentType, null=True)
+    content_type = models.ForeignKey(ContentType, null=True, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField(null=True, db_index=True)
     content_object = GenericForeignKey('content_type', 'object_id')
 

--- a/inyoka/portal/user.py
+++ b/inyoka/portal/user.py
@@ -549,7 +549,7 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
 
 
 class UserPage(models.Model):
-    user = models.OneToOneField(User)
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
     content = InyokaMarkupField()
 
 

--- a/inyoka/wiki/migrations/0001_initial.py
+++ b/inyoka/wiki/migrations/0001_initial.py
@@ -58,8 +58,8 @@ class Migration(migrations.Migration):
                 ('note', models.CharField(max_length=512)),
                 ('deleted', models.BooleanField(default=False)),
                 ('remote_addr', models.CharField(max_length=200, null=True)),
-                ('attachment', models.ForeignKey(blank=True, to='wiki.Attachment', null=True)),
-                ('page', models.ForeignKey(related_name='revisions', to='wiki.Page')),
+                ('attachment', models.ForeignKey(blank=True, to='wiki.Attachment', null=True, on_delete=models.CASCADE)),
+                ('page', models.ForeignKey(related_name='revisions', to='wiki.Page', on_delete=models.CASCADE)),
             ],
             options={
                 'ordering': ['-change_date'],
@@ -82,19 +82,19 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='revision',
             name='text',
-            field=models.ForeignKey(related_name='revisions', to='wiki.Text'),
+            field=models.ForeignKey(related_name='revisions', to='wiki.Text', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='revision',
             name='user',
-            field=models.ForeignKey(related_name='wiki_revisions', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(related_name='wiki_revisions', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
             model_name='page',
             name='last_rev',
-            field=models.ForeignKey(related_name='+', to='wiki.Revision', null=True),
+            field=models.ForeignKey(related_name='+', to='wiki.Revision', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AddField(
@@ -106,7 +106,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='metadata',
             name='page',
-            field=models.ForeignKey(to='wiki.Page'),
+            field=models.ForeignKey(to='wiki.Page', on_delete=models.CASCADE),
             preserve_default=True,
         ),
     ]

--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -813,9 +813,8 @@ class Page(models.Model):
     """
     objects = PageManager()
     name = models.CharField(max_length=200, unique=True, db_index=True)
-    topic = models.ForeignKey('forum.Topic', null=True,
-                              on_delete=models.PROTECT)
-    last_rev = models.ForeignKey('Revision', null=True, related_name='+')
+    topic = models.ForeignKey('forum.Topic', null=True, on_delete=models.PROTECT)
+    last_rev = models.ForeignKey('Revision', null=True, related_name='+', on_delete=models.CASCADE)
 
     #: this points to a revision if created with a query method
     #: that attaches revisions. Also creating a page object using
@@ -1243,15 +1242,15 @@ class Revision(models.Model):
             be ignored.
     """
     objects = RevisionManager()
-    page = models.ForeignKey(Page, related_name='revisions')
-    text = models.ForeignKey(Text, related_name='revisions')
+    page = models.ForeignKey(Page, related_name='revisions', on_delete=models.CASCADE)
+    text = models.ForeignKey(Text, related_name='revisions', on_delete=models.CASCADE)
     user = models.ForeignKey('portal.User', related_name='wiki_revisions',
-                             null=True, blank=True)
+                             null=True, blank=True, on_delete=models.CASCADE)
     change_date = models.DateTimeField(db_index=True)
     note = models.CharField(max_length=512)
     deleted = models.BooleanField(default=False)
     remote_addr = models.CharField(max_length=200, null=True)
-    attachment = models.ForeignKey(Attachment, null=True, blank=True)
+    attachment = models.ForeignKey(Attachment, null=True, blank=True, on_delete=models.CASCADE)
 
     @property
     def title(self):
@@ -1337,6 +1336,6 @@ class MetaData(models.Model):
     This should be considered being a private class because it is wrapped
     by the `Page.metadata` property and the `Page.update_meta` method.
     """
-    page = models.ForeignKey(Page)
+    page = models.ForeignKey(Page, on_delete=models.CASCADE)
     key = models.CharField(max_length=30, db_index=True)
     value = models.CharField(max_length=255, db_index=True)


### PR DESCRIPTION
Already deprecated and required with Djang 2.0.

see https://docs.djangoproject.com/en/3.0/releases/1.9/#foreignkey-and-onetoonefield-on-delete-argument