### PR TITLE
Render ImageCaptchaWidget with type="text"

### DIFF
--- a/inyoka/utils/forms.py
+++ b/inyoka/utils/forms.py
@@ -261,7 +261,7 @@ class ImageCaptchaWidget(TextInput):
     template_name = 'forms/widgets/image_captcha.html'
 
     def get_context(self, name, value, attrs):
-        context = super(Input, self).get_context(name, value, attrs)
+        context = super().get_context(name, value, attrs)
         context['widget']['captcha_url'] = href('portal', __service__='portal.get_captcha',
                                                 rnd=randrange(1, sys.maxsize))
         return context


### PR DESCRIPTION
ImageCaptchaWidget did only render with `type=""` on http://ubuntuusers.local:8080/register/

This was caused by calling `super(Input,…)` instead of `super(TextInput,…)`

To prevent this issue in the future, it now uses a python3 `super()` without a explicit class.