### PR TITLE
Bump MarkupSafe to 1.1.1

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -16,7 +16,7 @@ html5lib==1.0b8
 icalendar==4.0.0
 Jinja2==2.10.1
 lxml==4.1.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 Pillow==7.2.0
 psycopg2==2.8.5
 pyasn1_modules==0.1.5


### PR DESCRIPTION
MarkupSafe==1.0 was incompatible with setuptools > 45.3.0, see https://github.com/inyokaproject/inyoka/issues/1142

According to my ag-searches MarkupSafe is only used in jinja and not in
Inyoka, directly. So bump it to the newest version, that resolves the
issue.