### PR TITLE
Requirements: Remove `--no-binary`

### DIFF
--- a/extra/requirements/production.txt
+++ b/extra/requirements/production.txt
@@ -1,4 +1,3 @@
---no-binary lxml,Pillow
 Babel==2.5.1
 beautifulsoup4==4.6.0
 celery[redis]==4.3


### PR DESCRIPTION
Nowadays, seems to work fine (locally) and in jenkins. So, the build/deploy times only decrease.