### PR TITLE
Fix RecursionError on markup.parsertools.flatten_iterator (Python 3 vs 2)

### DIFF
--- a/inyoka/markup/parsertools.py
+++ b/inyoka/markup/parsertools.py
@@ -191,7 +191,7 @@ class MultiMap(dict):
 def flatten_iterator(iter):
     """Flatten an iterator to one without any sub-elements"""
     for item in iter:
-        if hasattr(item, '__iter__'):
+        if hasattr(item, '__iter__') and not isinstance(item, str):
             for sub in flatten_iterator(item):
                 yield sub
         else:


### PR DESCRIPTION
Error messages was

    RecursionError: maximum recursion depth exceeded while calling a
    Python object

This is caused by different behaviour between Python 3 and 2.
On Python 3

    >>> hasattr('a', '__iter__')
    True

On Python 2 this was `False`.

As there seems to be no 'native' Python way of doing it, the simplest
solution is to exclude strings to prevent the recursion error.