### PR TITLE
Typerror ubuntu version

### DIFF
--- a/inyoka/portal/utils.py
+++ b/inyoka/portal/utils.py
@@ -93,7 +93,7 @@ def google_calendarize(event):
     return s + '&trp=false'
 
 
-class UbuntuVersion(object):
+class UbuntuVersion:
     """
     This class holds a single Ubuntu version. Based on the settings for
     :py:attr:`lts`, :py:attr:`active`, :py:attr:`current`, :py:attr:`dev`, a
@@ -140,6 +140,9 @@ class UbuntuVersion(object):
         o = list(map(int, other.number.split('.')))
         #: Sort by major number and if they are the same, by minor version
         return s[0] > o[0] or s[0] == o[0] and s[1] > o[1]
+
+    def __hash__(self):
+        return hash(self.number) ^ hash(self.name)
 
     def as_json(self):
         data = {


### PR DESCRIPTION
Related to #1158 

The execption did not show in sentry, because of a bare expect-block (!)
in get_ubuntu_versions.

The execption was reproducable locally with

```
$ python manage.py shell
Python 3.8.6 (default, Sep 30 2020, 04:00:38)
[GCC 10.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> from inyoka.utils.storage import storage
>>> from inyoka.portal.utils import UbuntuVersion
>>> from inyoka.portal.utils import get_ubuntu_versions
>>> import json
>>> storage['distri_versions']
'[{"number":"4.10","name":"Warty Warthog","lts":false,"active":false,"current":false,"dev":false},{"number":"5.04","name":"Hoary Hedgehog","lts":false,"active":false,"current":false,"dev":false},{"number":"5.10","name":"Breezy Badger","lts":false,"active":false,"current":false,"dev":false},{"number":"6.06","name":"Dapper Drake","lts":true,"active":false,"current":false,"dev":false},{"number":"6.10","name":"Edgy Eft","lts":false,"active":false,"current":false,"dev":false},{"number":"7.04","name":"Feisty Fawn","lts":false,"active":false,"current":false,"dev":false},{"number":"7.10","name":"Gutsy Gibbon","lts":false,"active":false,"current":false,"dev":false},{"number":"8.04","name":"Hardy Heron","lts":true,"active":false,"current":false,"dev":false},{"number":"8.10","name":"Intrepid Ibex","lts":false,"active":false,"current":false,"dev":false},{"number":"9.04","name":"Jaunty Jackalope","lts":false,"active":false,"current":false,"dev":false},{"number":"9.10","name":"Karmic Koala","lts":false,"active":false,"current":false,"dev":false},{"number":"10.04","name":"Lucid Lynx","lts":true,"active":false,"current":false,"dev":false},{"number":"10.10","name":"Maverick Meerkat","lts":false,"active":false,"current":false,"dev":false},{"number":"11.04","name":"Natty Narwhal","lts":false,"active":false,"current":false,"dev":false},{"number":"11.10","name":"Oneiric Ocelot","lts":false,"active":false,"current":false,"dev":false},{"number":"12.04","name":"Precise Pangolin","lts":true,"active":false,"current":false,"dev":false},{"number":"12.10","name":"Quantal Quetzal","lts":false,"active":false,"current":false,"dev":false},{"number":"13.04","name":"Raring Ringtail","lts":false,"active":false,"current":false,"dev":false},{"number":"13.10","name":"Saucy Salamander","lts":false,"active":false,"current":false,"dev":false},{"number":"14.04","name":"Trusty Tahr","lts":true,"active":true,"current":false,"dev":false},{"number":"14.10","name":"Utopic Unicorn","lts":false,"active":false,"current":false,"dev":false},{"number":"15.04","name":"Vivid Vervet","lts":false,"active":false,"current":false,"dev":false},{"number":"15.10","name":"Wily Werewolf","lts":false,"active":false,"current":false,"dev":false},{"number":"16.04","name":"Xenial Xerus","lts":true,"active":true,"current":false,"dev":false},{"number":"16.10","name":"Yakkety Yak","lts":false,"active":false,"current":false,"dev":false},{"number":"17.04","name":"Zesty Zapus","lts":false,"active":false,"current":false,"dev":false},{"number":"17.10","name":"Artful Aardvark","lts":false,"active":true,"current":false,"dev":false},{"number":"18.04","name":"Bionic Beaver","lts":true,"active":true,"current":true,"dev":false},{"number":"18.10","name":"Cosmic Cuttlefish","lts":false,"active":false,"current":false,"dev":true}]'
>>> versions = set([])
>>> jsonobjs = json.loads(storage['distri_versions'])
>>> for obj in jsonobjs:
...     version = UbuntuVersion(**obj)
...     versions.add(version)
...
Traceback (most recent call last):
  File "<console>", line 3, in <module>
TypeError: unhashable type: 'UbuntuVersion'

>>> for obj in jsonobjs:
...     version = UbuntuVersion(**obj)
...     versions.add(version)
...
Traceback (most recent call last):
  File "<console>", line 3, in <module>
TypeError: unhashable type: 'UbuntuVersion'
```