### PR TITLE
Fix taglist after python3 migration

### DIFF
--- a/inyoka/wiki/macros.py
+++ b/inyoka/wiki/macros.py
@@ -10,8 +10,6 @@
 """
 import itertools
 import operator
-import random
-import string
 
 from django.conf import settings
 from django.utils.translation import ugettext as _
@@ -206,7 +204,7 @@ class TagList(macros.Macro):
         result = nodes.List('unordered', class_='taglist')
         if active_tag:
             pages = Page.objects.find_by_tag(active_tag)
-            for page in sorted(pages, key=string.lower):
+            for page in sorted(pages, key=str.lower):
                 item = nodes.ListItem([nodes.InternalLink(page)])
                 result.children.append(item)
         else:

--- a/tests/apps/wiki/test_macros.py
+++ b/tests/apps/wiki/test_macros.py
@@ -9,7 +9,7 @@
     :license: BSD, see LICENSE for more details.
 """
 from inyoka.markup import macros
-from inyoka.markup.base import RenderContext
+from inyoka.markup.base import RenderContext, parse
 from inyoka.utils.test import TestCase
 from inyoka.utils.urls import href
 from inyoka.wiki.models import Page
@@ -27,5 +27,16 @@ class TestWikiMacros(TestCase):
         at1 = gm('Attachment', ('internal_page', 'sometext'), {})
         link = at1.build_node(ct, 'html')
         self.assertEqual(link.href, href('wiki', '_attachment',
-                            target='AttachmentTest/internal_page'))
+                         target='AttachmentTest/internal_page'))
         self.assertEqual(link.text, 'sometext')
+
+    def test_taglist(self):
+        page = Page(name='Something')
+        html = parse("""[[TagListe("Ubuntu Touch")]]""").render(
+            RenderContext(wiki_page=page, application='wiki'),
+            format='html'
+        )
+
+        needle = '<div><h3 id="Pages-with-tag-Ubuntu-Touch" class="head">Pages with tag “Ubuntu Touch”' \
+                 '<a href="#Pages-with-tag-Ubuntu-Touch" class="headerlink">¶</a></h3><ul class="taglist"></ul></div>'
+        self.assertInHTML(needle, html)


### PR DESCRIPTION
Reported via https://forum.ubuntuusers.de/topic/tagliste-tagname-liefert-kein-ergebnis

The traceback seems to be missed with the migration to python3,
as the string-module has no lower-function anymore.
The fix just uses the builtin str instead of the string module
(str works on unicode in python3, too).

The simple added test has been previously failed with the following traceback:

```
ERROR: test_taglist (tests.apps.wiki.test_macros.TestWikiMacros)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/chris/Dev/inyoka/tests/apps/wiki/test_macros.py", line 37, in test_taglist
    format='html'
  File "/home/chris/Dev/inyoka/inyoka/markup/machine.py", line 68, in render
    return Renderer(self).render(context, format)
  File "/home/chris/Dev/inyoka/inyoka/markup/machine.py", line 234, in render
    return ''.join(self.stream(context, format))
  File "/home/chris/Dev/inyoka/inyoka/markup/machine.py", line 223, in stream
    yield instruction.render(context, format)
  File "/home/chris/Dev/inyoka/inyoka/markup/macros.py", line 101, in render
    rv = self.build_node(context, format)
  File "/home/chris/Dev/inyoka/inyoka/wiki/macros.py", line 209, in build_node
    for page in sorted(pages, key=string.lower):
AttributeError: module 'string' has no attribute 'lower'
```