### PR TITLE
Fixes #1206: Fix wiki feed urls

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -1377,8 +1377,8 @@ def feedselector(request, app=None):
                     return HttpResponseRedirect(href('wiki', '_feed',
                            data['count']))
                 else:
-                    return HttpResponseRedirect(href('wiki', '_feed',
-                           data['page'], data['count']))
+                    return HttpResponseRedirect(href('wiki', data['page'],
+                           'a', 'feed', data['count']))
 
     return {
         'app': app,


### PR DESCRIPTION
As noticed in #1206: On [https://ubuntuusers.de/feeds/](https://ubuntuusers.de/feeds/) single wikipage’s feed url were wrong. Fixed now.