### PR TITLE
Forum, markread: Raise 404, if forum-slug is not found

### DIFF
--- a/inyoka/forum/views.py
+++ b/inyoka/forum/views.py
@@ -21,7 +21,7 @@ from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import F, Q
 from django.http import Http404, HttpResponseRedirect
-from django.shortcuts import redirect
+from django.shortcuts import redirect, get_object_or_404
 from django.utils.text import Truncator
 from django.utils.translation import ugettext as _, ugettext_lazy
 from django.views.generic import CreateView, DetailView, UpdateView
@@ -1553,7 +1553,7 @@ def markread(request, slug=None):
         messages.info(request, _('Please login to mark posts as read.'))
         return HttpResponseRedirect(href('forum'))
     if slug:
-        forum = Forum.objects.get(slug=slug)
+        forum = get_object_or_404(Forum, slug=slug)
         forum.mark_read(user)
         user.save()
         messages.success(request,


### PR DESCRIPTION
Before the fix, one of the new added tests failed

```
$ python manage.py test tests.apps.forum.test_views.TestMarkRead
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...E
======================================================================
ERROR: test_no_existing_forum (tests.apps.forum.test_views.TestMarkRead)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/chris/Dev/inyoka/tests/apps/forum/test_views.py", line 1565, in test_no_existing_forum
    response = self.client.get(url, follow=True)
[....]
  File "/home/chris/Dev/inyoka/inyoka/forum/views.py", line 1556, in markread
    forum = Forum.objects.get(slug=slug)
  File "/home/chris/Dev/inyoka/inyoka/forum/models.py", line 105, in get
    forum = self.get_cached(ident)
  File "/home/chris/Dev/inyoka/inyoka/forum/models.py", line 145, in get_cached
    forum = super(ForumManager, self).get(slug=slug)
  File "/home/chris/Dev/inyoka/venv3.5.2/lib/python3.5/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/home/chris/Dev/inyoka/venv3.5.2/lib/python3.5/site-packages/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
inyoka.forum.models.DoesNotExist: Forum matching query does not exist.

----------------------------------------------------------------------
Ran 4 tests in 0.554s
```

found by @KaiserBarbarossa in the wild.