### PR TITLE
Add ircs as an supported protocol

### DIFF
--- a/inyoka/markup/lexer.py
+++ b/inyoka/markup/lexer.py
@@ -90,7 +90,7 @@ class rule(object):
 # in use (like git or irc)
 _url_pattern = (
     # urls with netloc
-    r'(?:(?:https?|ftps?|file|ssh|mms|svn(?:\+ssh)?|git|dict|nntp|irc|'
+    r'(?:(?:https?|ftps?|file|ssh|mms|svn(?:\+ssh)?|git|dict|nntp|ircs?|'
     r'rsync|smb|apt)://|'
     # urls without netloc
     r'(?:mailto|telnet|s?news|sips?|skype|apt):)'


### PR DESCRIPTION
InterWiki links like `[ircs://irc.libera.chat/ubuntuusers #ubuntuusers]`
didn’t work because ircs wasn’t interpreted as an protocol.

This commit changes the regex

`r'(?:(?:https?|ftps?|file|ssh|mms|svn(?:\+ssh)?|git|dict|nntp|irc|'`

to

`r'(?:(?:https?|ftps?|file|ssh|mms|svn(?:\+ssh)?|git|dict|nntp|ircs?|'`

which allows using both irc:// and ircs:// in InterWiki links.