### PR TITLE
Fix unicode error in planet sync

### DIFF
--- a/inyoka/planet/tasks.py
+++ b/inyoka/planet/tasks.py
@@ -160,7 +160,7 @@ def sync():
                 except AttributeError:
                     max_length = None
                 if isinstance(locals()[n], str):
-                    setattr(entry, n, force_text(locals()[n][:max_length]).encode('utf-8'))
+                    setattr(entry, n, force_text(locals()[n][:max_length]))
                 else:
                     setattr(entry, n, locals()[n])
             try:


### PR DESCRIPTION
Previously, all new titles and texts had a prefix `b'`.
Latter is not wanted.