### PR TITLE
Planet, sync: Continue with next blog on SSLError

### DIFF
--- a/inyoka/planet/tasks.py
+++ b/inyoka/planet/tasks.py
@@ -14,6 +14,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import re
+import ssl
 import urllib
 
 import socket
@@ -71,7 +72,7 @@ def sync():
         # but the bozo bit might be defined.
         try:
             feed = feedparser.parse(blog.feed_url)
-        except (LookupError, urllib.error.URLError, socket.timeout, ConnectionError) as e:
+        except (LookupError, urllib.error.URLError, socket.timeout, ConnectionError, ssl.SSLError) as e:
             logger.debug('%s on %s' % (repr(e), blog.feed_url))
             continue
 


### PR DESCRIPTION
traceback in sentry was

```
SSLError: [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC] decryption failed or bad record mac (_ssl.c:1981)
  File "inyoka/planet/tasks.py", line 73, in sync
    feed = feedparser.parse(blog.feed_url)
  File "feedparser/api.py", line 241, in parse
    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
  File "feedparser/api.py", line 141, in _open_resource
    return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
  File "feedparser/http.py", line 200, in get
    f = opener.open(request)
  File "urllib/request.py", line 466, in open
    response = self._open(req, data)
  File "urllib/request.py", line 484, in _open
    '_open', req)
  File "urllib/request.py", line 444, in _call_chain
    result = func(*args)
  File "urllib/request.py", line 1304, in https_open
    context=self._context, check_hostname=self._check_hostname)
  File "urllib/request.py", line 1264, in do_open
    r = h.getresponse()
  File "http/client.py", line 1242, in getresponse
    response.begin()
  File "http/client.py", line 311, in begin
    version, status, reason = self._read_status()
  File "http/client.py", line 272, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
  File "socket.py", line 575, in readinto
    return self._sock.recv_into(b)
  File "ssl.py", line 929, in recv_into
    return self.read(nbytes, buffer)
  File "ssl.py", line 791, in read
    return self._sslobj.read(len, buffer)
  File "ssl.py", line 575, in read
    v = self._sslobj.read(len, buffer)
```