### PR TITLE
Remove custom SendmailEmailBackend

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -244,12 +244,6 @@ Notification
 
     Print a short message to STDOUT for each notification that is send by mail.
 
-.. py:data:: EMAIL_BACKEND
-
-    Defaults to: ``'inyoka.utils.mail.SendmailEmailBackend'``
-
-    See https://docs.djangoproject.com/en/2.2/ref/settings/#email-backend
-
 .. py:data:: EMAIL_SUBJECT_PREFIX
 
     Defaults to: ``'example.com: '``

--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -128,7 +128,6 @@ TAGCLOUD_SIZE = 100
 # prefix for the system mails
 EMAIL_SUBJECT_PREFIX = '%s: ' % BASE_DOMAIN_NAME
 
-EMAIL_BACKEND = 'inyoka.utils.mail.SendmailEmailBackend'
 
 # forum settings
 FORUM_LIMIT_UNREAD = 100

--- a/inyoka/utils/mail.py
+++ b/inyoka/utils/mail.py
@@ -8,11 +8,8 @@
     :copyright: (c) 2007-2022 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from subprocess import PIPE, Popen
-
 from django.conf import settings
 from django.core.mail import send_mail as django_send_mail
-from django.core.mail.backends.base import BaseEmailBackend
 
 from inyoka.utils.logger import logger
 
@@ -43,49 +40,3 @@ def is_blocked_host(email_or_host):
     host = email_or_host.rsplit('@', 1)[-1]
     blocked_hosts = storage['blocked_hosts']
     return blocked_hosts and host in blocked_hosts.split()
-
-
-class SendmailEmailBackend(BaseEmailBackend):
-    def __init__(self, fail_silently=False, **kwargs):
-        super(SendmailEmailBackend, self).__init__(fail_silently=fail_silently)
-
-    def open(self):
-        return True
-
-    def close(self):
-        pass
-
-    def send_messages(self, email_messages):
-        """
-        Sends one or more EmailMessage objects and returns the number of email
-        messages sent.
-        """
-        if not email_messages:
-            return
-        num_sent = 0
-        for message in email_messages:
-            sent = self._send(message)
-            if sent:
-                num_sent += 1
-        return num_sent
-
-    def _send(self, email_message):
-        """A helper method that does the actual sending."""
-        if not email_message.recipients():
-            return False
-        try:
-            cmd = ['/usr/sbin/sendmail',
-                   '-f',
-                   settings.INYOKA_SYSTEM_USER_EMAIL,
-                   '-t']
-            proc = Popen(cmd, stdin=PIPE)
-            proc.stdin.write(email_message.message().as_bytes())
-            proc.stdin.flush()
-            proc.stdin.close()
-            # replace with os.wait() in a outer level to not wait to much?!
-            proc.wait()
-        except:
-            if not self.fail_silently:
-                raise
-            return False
-        return True


### PR DESCRIPTION
With the docker setup, it is no longer used in production environment on ubuntuusers.de

Instead djangos default SMTP backend can be used.