### PR TITLE
Add task to render all wikipages

### DIFF
--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -312,6 +312,10 @@ CELERY_BEAT_SCHEDULE = {
     'update_page_by_slug': {
         'task': 'inyoka.wiki.tasks.update_page_by_slug',
         'schedule': timedelta(hours=1),
+    },
+    'render_all_wiki_pages': {
+        'task': 'inyoka.wiki.tasks.render_all_pages',
+        'schedule': crontab(hour=23, minute=5),
     }
 }
 

--- a/inyoka/wiki/tasks.py
+++ b/inyoka/wiki/tasks.py
@@ -109,3 +109,12 @@ def update_recentchanges():
                 'note': revision.note
             })
     cache.set('wiki/recentchanges', recentchanges)
+
+
+@shared_task
+def render_all_pages():
+    """
+    Prerenders all wiki pages.
+    """
+    from inyoka.wiki.models import Page
+    Page.objects.render_all_pages()


### PR DESCRIPTION
The task will render all existing wiki pages, so they are all in the cache for a faster (first) retrival.

The tasks starts at 23:05, as it can take hours possibly.