### PR TITLE
Use default django classes for templates

### DIFF
--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -419,16 +419,11 @@ TEMPLATES = [
         'NAME': 'django',
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [],
-        'APP_DIRS': False,
-        'OPTIONS': {
-            'loaders': [
-                'inyoka.utils.templating.DjangoLoader',
-            ]
-        },
+        'APP_DIRS': True,
     },
     {
         'NAME': 'jinja',
-        'BACKEND': 'inyoka.utils.templating.Jinja2Templates',
+        'BACKEND': 'django.template.backends.jinja2.Jinja2',
         'DIRS': [],
         'APP_DIRS': True,
         'OPTIONS': {

--- a/inyoka/utils/templating.py
+++ b/inyoka/utils/templating.py
@@ -202,24 +202,6 @@ def environment(**options):
 
     return env
 
-# TODO: Reevaluate if needed for debug toolbar or so
-#    def _compile(self, source, filename):
-#        filename = 'jinja:/' + filename if filename.startswith('/') else filename
-#        code = compile(source, filename, 'exec')
-#        return code
-
-
-class DjangoLoader(Loader):
-    def get_template_sources(self, template_name, skip=None):
-        if not template_name.startswith('debug_toolbar'):
-            return []
-        return super().get_template_sources(template_name)
-
-
-class Jinja2Templates(Jinja2):
-    # TODO: Rename the templates folder in theme to jinja2, then we can drop this class and DjangoLoader
-    app_dirname = 'templates'
-
 
 #: Filters that are globally available in the template environment
 FILTERS = {


### PR DESCRIPTION
 - after the template-folder in the theme is renamed, we can use djangos default classes. The customized inyoka ones are not needed anymore.
 - `'APP_DIRS': True` for the django templates is needed by the django debug toolbar (according to their documentation) Without the folder rename it was not possible to use the debug toolbar.

Part of #1224 
needs https://github.com/inyokaproject/theme-ubuntuusers/pull/475