### PR TITLE
Forum, delete Post: Use permission per forum

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -52,6 +52,8 @@ Deployment notes
 🐛 Fixes
 --------
 
+* `To delete posts in the forum, permission per forum are used instead of one global permission. The global permisson could not be configured via the webinterface <https://github.com/inyokaproject/inyoka/pull/1267>`_
+
 🔒 Security
 -----------
 

--- a/inyoka/forum/views.py
+++ b/inyoka/forum/views.py
@@ -1277,7 +1277,7 @@ def delete_post(request, post_id, action='hide'):
         request.user.has_perm('forum.moderate_forum', topic.forum) and
         not (post.author_id == request.user.id and post.check_ownpost_limit('delete'))
     )
-    can_delete = can_hide and request.user.has_perm('forum.delete_topic_forum')
+    can_delete = can_hide and request.user.has_perm('forum.delete_topic_forum', topic.forum)
 
     if action == 'delete' and not can_delete:
         return abort_access_denied(request)


### PR DESCRIPTION
Instead of the global permission, use forum.delete_topic_forum per forum.

'forum.delete_topic_forum' is filtered in GroupGlobalPermissionForm. Thus, the global permission is not shown in the webinterface and can not be configured.

`def delete_topic` already used a permission per forum (not the global permission). Later was changed in commit 90d4840909c27b89086c71d6faa5c4895e403aeb.