### PR TITLE
Replace `setup.py develop` with `pip install`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
       working-directory: ./theme-ubuntuusers
       run: |
         . ~/venv/bin/activate
-        python setup.py develop
+        pip install -e .
 
     - name: Build static files
       working-directory: ./theme-ubuntuusers


### PR DESCRIPTION
During docker image builds f.e. the following was shown:

```
15 [inyoka_base 10/11] RUN sh -c 'cd /inyoka/theme && /inyoka/venv/bin/python setup.py develop'
15 0.309 running develop
15 0.311 /inyoka/venv/lib/python3.9/site-packages/setuptools/command/develop.py:40: EasyInstallDeprecationWarning: easy_install command is deprecated.
15 0.311 !!
15 0.311
15 0.311         ********************************************************************************
15 0.311         Please avoid running ``setup.py`` and ``easy_install``.
15 0.311         Instead, use pypa/build, pypa/installer, pypa/build or
15 0.311         other standards-based tools.
15 0.311
15 0.311         See https://github.com/pypa/setuptools/issues/917 for details.
15 0.311         ********************************************************************************
15 0.311
15 0.311 !!
15 0.311   easy_install.initialize_options(self)
15 0.323 /inyoka/venv/lib/python3.9/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
15 0.323 !!
15 0.323
15 0.323         ********************************************************************************
15 0.323         Please avoid running ``setup.py`` directly.
15 0.323         Instead, use pypa/build, pypa/installer, pypa/build or
15 0.323         other standards-based tools.
15 0.323
15 0.323         See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
15 0.323         ********************************************************************************
15 0.323
15 0.323 !!
15 0.323   self.initialize_options()
```

The last link also provides some background about the why and common replacements.