### PR TITLE
Make Ikhaya service robuster

### DIFF
--- a/inyoka/ikhaya/services.py
+++ b/inyoka/ikhaya/services.py
@@ -5,6 +5,8 @@
     :copyright: (c) 2007-2023 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
+from django.http import HttpResponseBadRequest
+from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_POST
 from inyoka.ikhaya.models import Suggestion
 from inyoka.portal.models import User
@@ -18,13 +20,17 @@ dispatcher = SimpleDispatcher()
 @dispatcher.register()
 def change_suggestion_assignment(request):
     post = request.POST
+
+    if 'username' not in post or 'suggestion' not in post:
+        return HttpResponseBadRequest()
+
     username, suggestion = post['username'], post['suggestion']
-    suggestion = Suggestion.objects.get(id=suggestion)
+    suggestion = get_object_or_404(Suggestion, id=suggestion)
 
     if username == '-':
         suggestion.owner = None
-        suggestion.save()
     else:
-        suggestion.owner = User.objects.get(username__iexact=username)
-        suggestion.save()
+        suggestion.owner = get_object_or_404(User, username__iexact=username)
+
+    suggestion.save()
     return True


### PR DESCRIPTION
Eliminate some lines where an exception could occur. Instead return a errors via HTTP-status-codes.
Traceback in sentry for missing check of post-keys was

```
KeyError: 'username'
  File "django/utils/datastructures.py", line 76, in __getitem__
    list_ = super().__getitem__(key)

MultiValueDictKeyError: 'username'
  File "django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "django/utils/deprecation.py", line 116, in __call__
    response = self.process_request(request)
  File "inyoka/middlewares/services.py", line 40, in process_request
    response = call(request, parts[1])
  File "inyoka/utils/services.py", line 33, in __call__
    return self.methods[name](request)
  File "inyoka/ikhaya/services.py", line 22, in change_suggestion_assignment
    username, suggestion = post['username'], post['suggestion']
  File "django/utils/datastructures.py", line 78, in __getitem__
    raise MultiValueDictKeyError(key)
```