### PR TITLE
Cache anonymous & system user in redis

### DIFF
--- a/inyoka/portal/forms.py
+++ b/inyoka/portal/forms.py
@@ -46,7 +46,7 @@ from inyoka.portal.user import (
     send_new_email_confirmation,
     set_new_email,
     reactivate_user,
-    reset_email, UserBanned
+    reset_email, UserBanned, UserManager
 )
 from inyoka.utils.dates import TIMEZONES
 from inyoka.utils.forms import (
@@ -813,6 +813,7 @@ class GroupGlobalPermissionForm(forms.Form):
             for app in self.MANAGED_APPS:
                 self._sync_permissions(app)
             cache.delete_pattern('/acl/*')
+            cache.delete_many([UserManager.CACHE_KEY_ANONYMOUS_USER, UserManager.CACHE_KEY_SYSTEM_USER])
 
     def __init__(self, *args, **kwargs):
         initial = {}
@@ -903,6 +904,7 @@ class GroupForumPermissionForm(forms.Form):
             for perm in delete_permissions:
                 remove_perm(perm, self.instance, forum)
         cache.delete_pattern('/acl/*')
+        cache.delete_many([UserManager.CACHE_KEY_ANONYMOUS_USER, UserManager.CACHE_KEY_SYSTEM_USER])
 
 
 class PrivateMessageForm(forms.Form):

--- a/tests/apps/forum/test_views.py
+++ b/tests/apps/forum/test_views.py
@@ -1610,7 +1610,7 @@ class TestPostFeed(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_queries(self):
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(7):
             self.client.get('/feeds/full/50/')
 
     def test_topic_hidden(self):
@@ -1723,7 +1723,7 @@ class TestPostForumFeed(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_queries(self):
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(7):
             self.client.get(f'/feeds/forum/{self.forum.name}/full/50/')
 
     def test_child_forum(self):
@@ -1862,7 +1862,7 @@ class TestTopicFeed(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_queries(self):
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(7):
             self.client.get(f'/feeds/topic/{self.topic.slug}/full/50/')
 
     def test_multiple_posts(self):

--- a/tests/apps/ikhaya/test_views.py
+++ b/tests/apps/ikhaya/test_views.py
@@ -296,7 +296,7 @@ class TestArticleFeeds(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_queries(self):
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             self.client.get('/feeds/full/50/')
 
     def test_multiple_articles(self):
@@ -437,7 +437,7 @@ class TestArticleCategoryFeeds(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_queries(self):
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             self.client.get(f'/feeds/{self.cat.slug}/full/50/')
 
     def test_multiple_articles(self):
@@ -527,7 +527,7 @@ class TestCommentsFeed(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_queries(self):
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             self.client.get(f'/feeds/comments/full/50/')
 
     def test_multiple_comments(self):
@@ -610,7 +610,7 @@ class TestCommentsPerArticleFeed(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_queries(self):
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             self.client.get(f'/feeds/comments/{self.article.id}/full/50/')
 
     def test_multiple_comments(self):

--- a/tests/apps/wiki/test_views.py
+++ b/tests/apps/wiki/test_views.py
@@ -354,7 +354,7 @@ class TestRevisionFeed(TestCase):
         self.assertEqual(len(feed.entries), 2)
 
     def test_queries(self):
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             self.client.get('/_feed/10/')
 
     def test_content_exact(self):
@@ -428,7 +428,7 @@ class TestArticleRevisionFeed(TestCase):
         self.assertIn('anonymous user deleted', response.content.decode())
 
     def test_queries(self):
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             self.client.get(self.page.get_absolute_url('feed'))
 
     def test_tags(self):

--- a/tests/bdd/steps/database.py
+++ b/tests/bdd/steps/database.py
@@ -34,10 +34,12 @@ def step_impl(context, username, status_string):
 @given('I have the permission "{permission}"')
 def step_impl(context, permission):
     from guardian.shortcuts import assign_perm
+    from inyoka.portal.user import UserManager
 
     group = context.user.groups.get_queryset()[0]
     assign_perm(permission, group)
     cache.delete_pattern('/acl/*')
+    cache.delete_many([UserManager.CACHE_KEY_ANONYMOUS_USER, UserManager.CACHE_KEY_SYSTEM_USER])
 
 
 @step('a "{item}" with caption "{caption}" exists')


### PR DESCRIPTION
follow up to https://github.com/inyokaproject/inyoka/pull/1295 with even more aggressive caching

After deploying the DB-index and reviewing some performance stats, we can decide whether the latter is needed or the index is 'good enough'

----

Tests: decrease query counter due to improved caching

----

The BDD tests failed, as each tests creates a new user object (with new ID in the database). Thus, in the next test a not existing user from the cache is used. The user has the wrong permissions. (just try `self.refresh_from_db()` on the cached anonymous user.
 It will raise `inyoka.portal.user.User.DoesNotExist`)

As a solution, cached users are dropped from redis cache after each test.

In reality the anonymous user(-id) should not change at all. Just to be safe, we drop the cache on permission changes.