### PR TITLE
add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,32 @@
+Christian (Fuchs) Loosli <git@fuchsnet.ch>
+Christian (Fuchs) Loosli <git@fuchsnet.ch> <develop@fuchsnet.ch>
+Christoph Volkert <inyoka@christoph-volkert.de>
+Christoph Volkert <inyoka@christoph-volkert.de> <chris34@users.noreply.github.com>
+Christoph Volkert <inyoka@christoph-volkert.de> <pcdos31-git@yahoo.de>
+Christopher Grebs <cg@webshox.org>
+Florian Apolloner <florian@apolloner.eu>
+Florian Apolloner <florian@apolloner.eu> <apollo13@apolloner.eu>
+Florian Apolloner <florian@apolloner.eu> <apollo13@users.noreply.github.com>
+Jonatan Zeidler <jonatan_zeidler@gmx.de>
+Jonatan Zeidler <jonatan_zeidler@gmx.de> 
+Lyra <lyra2108@gmail.com>
+Lyra <lyra2108@gmail.com> <github@sblume.eu>
+Lyra <lyra2108@gmail.com> <Lyra2108@users.noreply.github.com>
+Mario Fuest <fuestm@ubp.de> <mariofuest@aol.com>
+Markus Holtermann <markus@markusholtermann.eu>
+Markus Holtermann <markus@markusholtermann.eu> <info@markusholtermann.de>
+Markus Holtermann <markus@markusholtermann.eu> <inyoka@markusholtermann.eu>
+Markus Holtermann <markus@markusholtermann.eu> <markus@markusholtermann.de>
+Markus Seidel <intrepid@icd-xw.de>
+Markus Seidel <intrepid@icd-xw.de> <markus@markus-xps.(none)>
+Oskar Hahn <mail@oshahn.de>
+Philipp Schmidt <philipp@schmidt-rheinhausen.de>
+Philipp Schmidt <philipp@schmidt-rheinhausen.de> <philschmidt@gmx.net>
+Sebastian <sebix@sebix.at>
+Sebastian <sebix@sebix.at> <wagner@cert.at>
+Sören <wegener92@googlemail.com>
+Sören <wegener92@googlemail.com> <soeren@soeren-notebook.(none)>
+Sören <wegener92@googlemail.com> <wegener92@gmail.com>
+Stefan Betz <info@stefan-betz.net>
+Sujeevan Vijayakumaran <mail@svij.org>
+Sujeevan Vijayakumaran <mail@svij.org> <vijayakumaran@otris.de>


### PR DESCRIPTION
This will help git (and github?) to know which commits is owned by which person, at least more or less. At least it makes the outputt of `git shortlog -s -e -n` more useful, as over time, mail adresses have been changed.

Sadly, it does not bring our beloved hg or svn history we are missing.