### PR TITLE
Remove private messages after specific cache duration

### DIFF
--- a/inyoka/default_settings.py
+++ b/inyoka/default_settings.py
@@ -8,14 +8,13 @@
     :license: BSD, see LICENSE for more details.
 """
 from collections import OrderedDict
-
-import jinja2
 from datetime import timedelta
 from os.path import dirname, join
 
 from celery.schedules import crontab
 
 import inyoka
+import jinja2
 
 #: Base path of this application
 BASE_PATH = dirname(__file__)
@@ -151,6 +150,11 @@ ACTIVATION_HOURS = 48
 
 # days to describe an inactive user
 USER_INACTIVE_DAYS = 365
+
+# days after private messages
+# in specific folder will be removed
+PRIVATE_MESSAGE_TRASH_DURATION = 90
+PRIVATE_MESSAGE_INBOX_SENT_DURATION = 180
 
 # wiki settings
 WIKI_MAIN_PAGE = 'Welcome'
@@ -308,6 +312,10 @@ CELERY_BEAT_SCHEDULE = {
     'render_all_wiki_pages': {
         'task': 'inyoka.wiki.tasks.render_all_pages',
         'schedule': crontab(hour=23, minute=5),
+    },
+    'clean_private_message_folders': {
+        'task': 'inyoka.portal.tasks.clean_privmsg_folders',
+        'schedule': crontab(hour=6, minute=30, day_of_week='saturday'),
     }
 }
 

--- a/inyoka/portal/models.py
+++ b/inyoka/portal/models.py
@@ -193,6 +193,11 @@ class PrivateMessageEntry(models.Model):
     @classmethod
     @transaction.atomic
     def clean_private_message_folders(cls):
+        """
+        Remove all messages in private message folders (except 'archive')
+        after end of cache duration according to settings
+        has been reached.
+        """
         sent = PRIVMSG_FOLDERS['sent'][0]
         inbox = PRIVMSG_FOLDERS['inbox'][0]
         trash = PRIVMSG_FOLDERS['trash'][0]
@@ -200,12 +205,12 @@ class PrivateMessageEntry(models.Model):
             folder=trash,
             message__pub_date__lte=datetime.now() - timedelta(
                 days=settings.PRIVATE_MESSAGE_TRASH_DURATION),
-            ).exclude(user__groups__name__iexact=settings.INYOKA_TEAM_GROUP_NAME)
+            ).exclude(user__groups__name__exact=settings.INYOKA_TEAM_GROUP_NAME)
         privmsgs_inbox_sent = PrivateMessageEntry.objects.filter(
             folder__in=[inbox, sent],
             message__pub_date__lte=datetime.now() - timedelta(
                 days=settings.PRIVATE_MESSAGE_INBOX_SENT_DURATION),
-            ).exclude(user__groups__name__iexact=settings.INYOKA_TEAM_GROUP_NAME)
+            ).exclude(user__groups__name__exact=settings.INYOKA_TEAM_GROUP_NAME)
         privmsgs_trash.delete()
         privmsgs_inbox_sent.delete()
 

--- a/inyoka/portal/tasks.py
+++ b/inyoka/portal/tasks.py
@@ -83,10 +83,6 @@ def query_counter_task(cache_key, sql):
 
 @shared_task
 def clean_privmsg_folders():
-    """
-    Remove all messages in private message folders (except 'archive')
-    after end of cache duration according to settings
-    has been reached.
-    """
+    """Clean private message folders."""
     logger.info("Deleting private messages after end of cache duration")
     PrivateMessageEntry.clean_private_message_folders()

--- a/inyoka/portal/tasks.py
+++ b/inyoka/portal/tasks.py
@@ -88,16 +88,5 @@ def clean_privmsg_folders():
     after end of cache duration according to settings
     has been reached.
     """
-    privmsgs_trash = PrivateMessageEntry.objects.filter(
-        folder="2",
-        message__pub_date__lte=datetime.now() - timedelta(
-            days=settings.PRIVATE_MESSAGE_TRASH_DURATION),
-        )
-    privmsgs_inbox_sent = PrivateMessageEntry.objects.filter(
-        folder__in=["0", "1"],
-        message__pub_date__lte=datetime.now() - timedelta(
-            days=settings.PRIVATE_MESSAGE_INBOX_SENT_DURATION),
-        )
     logger.info("Deleting private messages after end of cache duration")
-    privmsgs_trash.delete()
-    privmsgs_inbox_sent.delete()
+    PrivateMessageEntry.clean_private_message_folders()


### PR DESCRIPTION
This will not affect messages in the 'archive' folder. Closes #372. Probably also a configuration option should be created for this, in case users want to disable it? At least there'll have to be an announcement for the changed behaviour.