### PR TITLE
Drop control characters on all POST requests

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -43,6 +43,9 @@ Deployment notes
 * Migrate from ``setup.py`` to ``pyproject.toml``
 * Introduce ruff for code formatting
 * Render ``<mark>`` for highlighted text
+* Control characters are stripped from all HTTP-POST parameters
+* Documentation: Now possible to use Markdown
+* Documentation is now published at https://doc.inyokaproject.org/
 
 🗑 Deprecations
 --------------

--- a/inyoka/middlewares/common.py
+++ b/inyoka/middlewares/common.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponse
 from django.middleware.common import CommonMiddleware
+from django.utils.functional import cached_property
 from django_hosts.middleware import HostsRequestMiddleware
 
 from inyoka.utils.local import local, local_manager
@@ -27,6 +28,24 @@ from inyoka.utils.timer import StopWatch
 
 class CommonServicesMiddleware(HostsRequestMiddleware, CommonMiddleware):
     """Hook in as first middleware for common tasks."""
+
+    @cached_property
+    def table_control_characters(self):
+        """
+        Returns a translation table which removes all control characters not allowed in XML/HTML.
+        Use it with `str.translate`.
+
+        The characters can be also described by the regex r'[\x00-\x08\x0B-\x0C\x0E-\x1F]'.
+        However, the regex performed slower in a little benchmark comparison.
+        """
+        table = {0x0B: None, 0x0C: None}
+        for i in range(0x0, 0x08 + 1):
+            table[i] = None
+
+        for i in range(0x0E, 0x1F + 1):
+            table[i] = None
+
+        return table
 
     def process_request(self, request):
         # populate the request
@@ -41,6 +60,16 @@ class CommonServicesMiddleware(HostsRequestMiddleware, CommonMiddleware):
         # It's also mentioned in https://datatracker.ietf.org/doc/html/rfc3986#section-7.3
         if '\x00' in request.path:
             return HttpResponse(content='The URL contained NUL characters', status=400, content_type='text/plain')
+
+        # remove control characters in all POST fields
+        # Thus, these will not slip into the DB and will not be displayed to users in HTML/XML
+        # request.POST does not contain file uploads
+        if request.method == "POST":
+            new_post = request.POST.copy()
+            for key, value_list in new_post.lists():
+                new_post.setlist(key, [v.translate(self.table_control_characters) for v in value_list])
+            new_post._mutable = False
+            request.POST = new_post
 
         # IMPORTANT: Since we run some setup-code (mainly locals), this middleware
         # needs to be the first one, hence we manually dispatch to HostsMiddleware

--- a/tests/utils/test_middleware.py
+++ b/tests/utils/test_middleware.py
@@ -8,7 +8,9 @@
     :license: BSD, see LICENSE for more details.
 """
 from django.conf import settings
+from django.test import RequestFactory
 
+from inyoka.middlewares.common import CommonServicesMiddleware
 from inyoka.utils.test import InyokaClient, TestCase
 
 
@@ -38,3 +40,10 @@ class TestServiceMiddleware(TestCase):
         url = f'http://{ settings.BASE_DOMAIN_NAME }/?__service__=portal.toggle_sidebar%27%7C%7CDBMS_PIPE.RECEIVE'
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
+
+    def test_control_characters_stripped_in_post(self):
+        self.factory = RequestFactory()
+        data = {'foobar': 'control characters \x08 \x0f in text'}
+        request = self.factory.post('/', data)
+        CommonServicesMiddleware(lambda x: x).process_request(request)
+        self.assertEqual(request.POST['foobar'], 'control characters   in text')


### PR DESCRIPTION
This will only prevent the insertion of new control characters into the DB. If there already control characters e.g. in a forum post, they will remain there for now.

follow up to #1294 as the PR did _not_ fix everything