### PR TITLE
InykoaMarkup: Dont strip whitespace in form fields

### DIFF
--- a/inyoka/forum/forms.py
+++ b/inyoka/forum/forms.py
@@ -70,7 +70,7 @@ class EditPostForm(SurgeProtectionMixin, forms.Form):
     This form takes the additional keyword argument `is_first_post`.
     It's generally used together with `AddAttachmentForm`.
     """
-    text = StrippedCharField(widget=forms.Textarea)
+    text = StrippedCharField(widget=forms.Textarea, strip=False)
     # the following fields only appear if the post is the first post of the
     # topic.
     #: the user can select, whether the post's topic should be sticky or not.
@@ -119,7 +119,7 @@ class NewTopicForm(SurgeProtectionMixin, forms.Form):
     """
     title = StrippedCharField(widget=forms.TextInput(attrs={'size': 60, 'spellcheck': 'true'}),
                               max_length=100)
-    text = StrippedCharField(widget=forms.Textarea)
+    text = StrippedCharField(widget=forms.Textarea, strip=False)
     ubuntu_version = forms.ChoiceField(required=False)
     ubuntu_distro = forms.ChoiceField(required=False)
     sticky = forms.BooleanField(required=False)

--- a/inyoka/ikhaya/forms.py
+++ b/inyoka/ikhaya/forms.py
@@ -48,7 +48,7 @@ class EditCommentForm(forms.Form):
     text = StrippedCharField(label=gettext_lazy('Text'), widget=forms.Textarea,
              help_text=gettext_lazy('To refer to another comment, you '
                'can write <code>@commentnumber</code>.<br />'
-               'Clicking on “reply” will automatically insert this code.'))
+               'Clicking on “reply” will automatically insert this code.'), strip=False)
 
 
 class EditArticleForm(forms.ModelForm):

--- a/tests/apps/ikhaya/test_forms.py
+++ b/tests/apps/ikhaya/test_forms.py
@@ -1,0 +1,37 @@
+"""
+    tests.apps.ikhaya.test_views
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test ikhaya forms.
+
+    :copyright: (c) 2012-2024 by the Inyoka Team, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+"""
+
+from inyoka.ikhaya.forms import EditCommentForm
+from inyoka.utils.test import TestCase
+
+
+class TestEditCommentForm(TestCase):
+    form = EditCommentForm
+
+    def test_text__whitespace_not_stripped(self):
+        text = ' * a \n * b\n'
+        data = {'text': text}
+
+        form = self.form(data)
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['text'], text)
+
+    def test_text__empty_text_rejected(self):
+        text = ' \n \t'
+        data = {'text': text}
+
+        form = self.form(data)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            'Text must not be empty',
+            form.errors['text'],
+        )


### PR DESCRIPTION
Otherwise valid InyokaMarkup like

```
 * a
 * b
```

will be rendered wrong, as the space before `* a` is stripped.

The `validate_empty_text` validator of `StrippedCharField` assures that still no empty content can be submitted.

Fix https://github.com/inyokaproject/inyoka/issues/1335