### PR TITLE
update installation requirements for Ubuntu 22.04 and Debian 12

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,14 +33,7 @@ For using Inyoka and its dependencies you need a lot of python and developer fil
 
 .. code-block:: console
 
-    $  sudo apt-get install git nodejs-legacy libxml2-dev libxslt1-dev libzmq-dev zlib1g-dev libjpeg-dev uuid-dev libfreetype6-dev libpq-dev build-essential libpq-dev libffi-dev python3-dev
-
-You also need the JavaScript package manager npm:
-
-.. code-block:: console
-
-    $ sudo apt-get install npm
-
+    $  sudo apt install git npm libxml2-dev libxslt1-dev libzmq3-dev zlib1g-dev libjpeg-dev uuid-dev libfreetype6-dev libpq-dev build-essential libpq-dev libffi-dev python3-dev python3-venv
 
 Inyoka installation
 *******************
@@ -129,7 +122,7 @@ supported by Django can have performance issues or less supported features! Inyo
 
 .. code-block:: console
 
-    $ sudo apt-get install postgresql redis-server
+    $ sudo apt install postgresql redis-server
 
 Next, you need a ``development_settings.py`` file which can be copied from
 the example file:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,7 +33,7 @@ For using Inyoka and its dependencies you need a lot of python and developer fil
 
 .. code-block:: console
 
-    $  sudo apt install git npm libxml2-dev libxslt1-dev libzmq3-dev zlib1g-dev libjpeg-dev uuid-dev libfreetype6-dev libpq-dev build-essential libpq-dev libffi-dev python3-dev python3-venv
+    $  sudo apt install git npm libxml2-dev libxslt1-dev zlib1g-dev libjpeg-dev uuid-dev libfreetype6-dev libpq-dev build-essential libpq-dev libffi-dev python3-dev python3-venv
 
 Inyoka installation
 *******************


### PR DESCRIPTION
These had old package names before, now we have the correct versions and package names, I also migrated it from apt-get to apt, and add the missing python3-venv package needed for our installation guide.

npm is now part of the single package installation instruction, no need to run apt twice for the application parts.