### PR TITLE
Wiki, pages: `render_all_pages` also updates metadata

### DIFF
--- a/inyoka/wiki/models.py
+++ b/inyoka/wiki/models.py
@@ -510,12 +510,14 @@ class PageManager(models.Manager):
 
         return attachment.file.name
 
-    def render_all_pages(self):
+    def render_all_pages(self) -> None:
         """
-        This method will rerender all wiki pages (only the newest revision of them and only non-privilged ones).
+        This method will rerender all wiki pages (only the newest revision of them and only non-privileged ones).
         If run on a schedule, it can guarantee that an up-to-date version is in the cache.
 
-        If a page is already in the cache, the cache entry will be dropped before rerendering it.
+        If a page is already in the cache, the cache entry will be dropped before rendering it.
+
+        The metadata of each page is also updated.
         """
         page_list = self.get_page_list(exclude_privileged=True)
 
@@ -530,6 +532,8 @@ class PageManager(models.Manager):
             if page.rev.attachment:
                 # page is an attachment
                 continue
+
+            page.update_meta()
 
             page.rev.text.remove_value_from_cache()
 


### PR DESCRIPTION
The metadata was invalid, if f.e. a included template was updated. Adding it to the nightly batch job to render all pages will fix the metadata.

------


The branch https://github.com/chris34/inyoka-pub/tree/wiki-update-related-metadata also contains with https://github.com/inyokaproject/inyoka/commit/8bf8873304d98c075b08d7a4502091e46e41aee6 a WIP commit that tries to render all related pages directly after a page was saved. That could be the next step to include in Inyoka.

First, I would test on staging if the nightly job here runs and especially how long it will take.