### PR TITLE
Login: Increase `max_length` of username field for mail addresses

### DIFF
--- a/inyoka/portal/forms.py
+++ b/inyoka/portal/forms.py
@@ -20,7 +20,7 @@ from django.contrib.auth import forms as auth_forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
 from django.contrib.auth.models import Group, Permission
-from django.core import signing
+from django.core import signing, validators
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
@@ -99,6 +99,12 @@ class LoginForm(AuthenticationForm):
     def __init__(self, request=None, *args, **kwargs):
         super().__init__(request, *args, **kwargs)
         self.fields['username'].label = _('Username or email address')
+
+        # adapt max length for emails (super class only considered username max_length)
+        username_max_length = max(User.username.field.max_length, User.email.field.max_length)
+        self.fields["username"].validators.append(validators.MaxLengthValidator(username_max_length))
+        self.fields["username"].max_length = username_max_length
+        self.fields["username"].widget.attrs["maxlength"] = username_max_length
 
         self.error_messages['inactive'] = format_html(
                 _("Login failed because the user is inactive. You probably didn’t click on the link in the "

--- a/tests/apps/portal/test_forms.py
+++ b/tests/apps/portal/test_forms.py
@@ -14,6 +14,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 
 from inyoka.portal.forms import EditFileForm, EditStaticPageForm, LoginForm
 from inyoka.portal.models import StaticFile, StaticPage
+from inyoka.portal.user import User
 from inyoka.utils.test import TestCase
 
 
@@ -198,3 +199,25 @@ class TestLoginForm(TestCase):
 
         self.assertFalse(form.is_valid())
         self.assertIn('Null characters are not allowed.', form.errors['username'])
+
+    def test_longer_email_as_username(self):
+        """
+        Form should be valid with an email that is longer than the maximum allowed length
+        of a username.
+        """
+        data = {'username': 'xxxx-xxxxxxx.xxxxxxx@inyoka-test.test', 'password': 'foo'}
+
+        User.objects.register_user('user', email=data['username'], password=data['password'], send_mail=False)
+
+        form = self.form(None, data)
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.errors, {})
+
+    def test_too_long_email_as_username(self):
+        data = {'username': f"{256 * 'x'}@inyoka.test", 'password': 'foo'}
+
+        form = self.form(None, data)
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors,  {'username': ['Ensure this value has at most 254 characters (it has 268).']})


### PR DESCRIPTION
The django form sets `max_length` of the form field to `max_length` of the `username` field in the `User` *model*.

However, in Inyoka we also allow to enter email adresses as usernames. These have a higher `max_length`.

Now the maximum of the email and username model-fields is used (which is at the moment the value of the email-field).