### PR TITLE
PrivateMessages: Fix RuntimeWarning for naive datetime

### DIFF
--- a/inyoka/portal/models.py
+++ b/inyoka/portal/models.py
@@ -11,7 +11,7 @@ import glob
 import gzip
 import hashlib
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -20,6 +20,7 @@ from django.core.cache import cache
 from django.core.validators import RegexValidator
 from django.db import models, transaction
 from django.db.models import Count
+from django.utils import timezone as dj_timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy
 
@@ -215,13 +216,13 @@ class PrivateMessageEntry(models.Model):
 
         privmsgs_trash = PrivateMessageEntry.objects.filter(
             folder=trash,
-            message__pub_date__lte=datetime.now() - timedelta(
+            message__pub_date__lte=dj_timezone.now() - timedelta(
                 days=settings.PRIVATE_MESSAGE_TRASH_DURATION),
             ).exclude(user__groups__name__exact=settings.INYOKA_TEAM_GROUP_NAME)
 
         privmsgs_inbox_sent = PrivateMessageEntry.objects.filter(
             folder__in=[inbox, sent],
-            message__pub_date__lte=datetime.now() - timedelta(
+            message__pub_date__lte=dj_timezone.now() - timedelta(
                 days=settings.PRIVATE_MESSAGE_INBOX_SENT_DURATION),
             ).exclude(user__groups__name__exact=settings.INYOKA_TEAM_GROUP_NAME)
 

--- a/tests/apps/portal/test_models.py
+++ b/tests/apps/portal/test_models.py
@@ -8,7 +8,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import gzip
-from datetime import datetime, timedelta
+from datetime import timedelta
 from os import path
 
 from django.conf import settings
@@ -191,7 +191,7 @@ class TestPrivateMessageEntry(TestCase):
             'other_user',
             'example2@example.com',
             'pwd', False)
-        pm = PrivateMessage(author=user, subject="Expired message", pub_date=datetime.now() -
+        pm = PrivateMessage(author=user, subject="Expired message", pub_date=dj_timezone.now() -
             timedelta(days=settings.PRIVATE_MESSAGE_INBOX_SENT_DURATION))
         pm.send([self.other_user])
 

--- a/tests/apps/portal/test_views.py
+++ b/tests/apps/portal/test_views.py
@@ -15,8 +15,8 @@ from django.core import mail
 from django.http import Http404
 from django.test import Client, RequestFactory
 from django.test.utils import override_settings
+from django.utils import timezone as dj_timezone
 from django.utils import translation
-from django.utils.timezone import now
 from django.utils.translation import gettext as _
 from freezegun import freeze_time
 from guardian.shortcuts import assign_perm
@@ -692,13 +692,13 @@ class TestPrivMsgViews(TestCase):
     def test_delete_many(self):
         user2 = User.objects.register_user('user2', 'user2@example.com', 'user', False)
         pm1 = PrivateMessage.objects.create(author=user2, subject='Subject',
-            text='Text', pub_date=now())
+            text='Text', pub_date=dj_timezone.now())
         PrivateMessageEntry.objects.create(message=pm1, user=user2,
             read=False, folder=PRIVMSG_FOLDERS['sent'][0])
         pme1 = PrivateMessageEntry.objects.create(message=pm1, user=self.user,
             read=False, folder=PRIVMSG_FOLDERS['inbox'][0])
         pm2 = PrivateMessage.objects.create(author=user2, subject='Subject',
-            text='Text', pub_date=now())
+            text='Text', pub_date=dj_timezone.now())
         PrivateMessageEntry.objects.create(message=pm2, user=user2,
             read=False, folder=PRIVMSG_FOLDERS['sent'][0])
         pme2 = PrivateMessageEntry.objects.create(message=pm2, user=self.user,


### PR DESCRIPTION
During test execution the following warnings were shown:

> RuntimeWarning: DateTimeField PrivateMessage.pub_date received
> a naive datetime while time zone support is active.