### PR TITLE
Event: Slug is changed for unpublished events

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -44,6 +44,7 @@ Deployment notes
 * Enable timezon-aware datetimes from Django
 * Fix deprecation warnings related to UTC methods
 * Remove private messages after specific duration. This will not affect messages in the 'archive' folder and team members.
+* Event: Slug is changed for unpublished events
 
 🗑 Deprecations
 --------------

--- a/inyoka/ikhaya/models.py
+++ b/inyoka/ikhaya/models.py
@@ -416,7 +416,7 @@ class Event(models.Model):
         }[action])
 
     def save(self, *args, **kwargs):
-        if not self.slug:
+        if not self.slug or not self.visible:
             name = self.start.astimezone().strftime('%Y/%m/%d/') + slugify(self.name)
             self.slug = find_next_increment(Event, 'slug', name)
 


### PR DESCRIPTION
Now, if the name of a hidden event is changed, the slug will be also changed.

If the event is published, the slug will not change. Mainly, to keep URLs stable.
(To intentionally change the slug of a published event, f.e. if it contains sensitive information, the event can be temporarily hidden to change the slug.)

Fix https://github.com/inyokaproject/inyoka/issues/520