### PR TITLE
Portal: Allow sidebar-customization via template file

### DIFF
--- a/inyoka/portal/jinja2/portal/index.html
+++ b/inyoka/portal/jinja2/portal/index.html
@@ -12,6 +12,9 @@
 {%- extends 'portal/overall.html' %}
 
 {% block pre_navigation %}
+
+  {% include 'portal/index_sidebar_additions.html' %}
+
   <div class="container calendar">
     <div class="calendar link">
       <h3><a href="{{ href('portal', 'calendar') }}">{% trans %}Upcoming events{% endtrans %}</a></h3>

--- a/inyoka/portal/jinja2/portal/index_sidebar_additions.html
+++ b/inyoka/portal/jinja2/portal/index_sidebar_additions.html
@@ -1,0 +1,9 @@
+{#
+    portal/index_sidebar_additions.html
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Dummy file that can be used to add items at the top of the sidebar in a custom theme.
+
+    :copyright: (c) 2007-2025 by the Inyoka Team, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+#}

--- a/inyoka/portal/jinja2/portal/overall.html
+++ b/inyoka/portal/jinja2/portal/overall.html
@@ -29,6 +29,9 @@
 {% block sidebar %}
   {%- block pre_navigation %}{% endblock -%}
   <div class="container">
+
+    {% include 'portal/overall_sidebar_additions.html' %}
+
     <h3 class="navi_ubuntuusers"><a href="{{ href('portal') }}">{{ BASE_DOMAIN_NAME }}</a></h3>
     <ul>
       <li><a href="{{ href('wiki', 'ubuntuusers') }}">{{ _('About') }} {{ BASE_DOMAIN_NAME }}</a></li>

--- a/inyoka/portal/jinja2/portal/overall_sidebar_additions.html
+++ b/inyoka/portal/jinja2/portal/overall_sidebar_additions.html
@@ -1,0 +1,9 @@
+{#
+    portal/overall_sidebar_additions.html
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Dummy file that can be used to add items at the top of the sidebar in a custom theme.
+
+    :copyright: (c) 2007-2025 by the Inyoka Team, see AUTHORS for more details.
+    :license: BSD, see LICENSE for more details.
+#}


### PR DESCRIPTION
The dummy template file can be replaced in an own theme like for ubuntuusers.
This makes additions to the sidebar easier.

Also HTML changes from Inyoka do not have to ported.