### PR TITLE
Planet, sync task: Skip blog on `IncompleteRead`

### DIFF
--- a/inyoka/planet/tasks.py
+++ b/inyoka/planet/tasks.py
@@ -20,6 +20,7 @@ import urllib
 # And further patch it so feedparser works :/
 import xml.sax
 from datetime import datetime, timezone
+from http.client import IncompleteRead
 from time import time
 
 import feedparser
@@ -68,7 +69,7 @@ def _sync():
         # but the bozo bit might be defined.
         try:
             feed = feedparser.parse(blog.feed_url)
-        except (LookupError, urllib.error.URLError, socket.timeout, ConnectionError, ssl.SSLError) as e:
+        except (LookupError, urllib.error.URLError, socket.timeout, ConnectionError, ssl.SSLError, IncompleteRead) as e:
             logger.debug('%s on %s' % (repr(e), blog.feed_url))
             continue
 


### PR DESCRIPTION
Instead of terminating the task, skip the blog that caused the `IncompleteRead`.

Traceback in sentry was

```
ValueError: invalid literal for int() with base 16: b''
  File "http/client.py", line 579, in _get_chunk_left
    chunk_left = self._read_next_chunk_size()
  File "http/client.py", line 546, in _read_next_chunk_size
    return int(line, 16)

IncompleteRead: IncompleteRead(0 bytes read)
  File "http/client.py", line 595, in _read_chunked
    while (chunk_left := self._get_chunk_left()) is not None:
  File "http/client.py", line 581, in _get_chunk_left
    raise IncompleteRead(b'')

IncompleteRead: IncompleteRead(20781 bytes read)
  File "celery/app/trace.py", line 736, in __protected_call__
    return self.run(*args, **kwargs)
  File "inyoka/planet/tasks.py", line 73, in sync
    feed = feedparser.parse(blog.feed_url)
  File "feedparser/api.py", line 216, in parse
    data = _open_resource(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
  File "feedparser/api.py", line 115, in _open_resource
    return http.get(url_file_stream_or_string, etag, modified, agent, referrer, handlers, request_headers, result)
  File "feedparser/http.py", line 172, in get
    data = f.read()
  File "http/client.py", line 473, in read
    return self._read_chunked(amt)
  File "http/client.py", line 607, in _read_chunked
    raise IncompleteRead(b''.join(value)) from exc
```