### PR TITLE
Activation key modernize

### DIFF
--- a/inyoka/portal/urls.py
+++ b/inyoka/portal/urls.py
@@ -62,7 +62,7 @@ urlpatterns = [
     path('whoisonline/', views.whoisonline),
     path('inyoka/', views.about_inyoka),
     path('register/', views.register),
-    re_path(r'^(?P<action>activate|delete)/(?P<username>[^/]+)/(?P<activation_key>.*?)/$', views.activate),
+    re_path(r'^activate/(?P<username>[^/]+)/(?P<activation_key>.*?)/$', views.activate),
     re_path(r'^confirm/(?P<action>reactivate_user|set_new_email|reset_email)/$', views.confirm),
     path('lost_password/', views.InyokaPasswordResetView.as_view()),
     re_path(r'^lost_password/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>.+)/$', views.InyokaPasswordResetConfirmView.as_view()),

--- a/inyoka/portal/user.py
+++ b/inyoka/portal/user.py
@@ -173,15 +173,14 @@ def reset_email(id, email):
 
 @sensitive_variables('message')
 def send_activation_mail(user):
-    """send an activation mail"""
     message = render_to_string('mails/activation_mail.txt', {
         'user': user,
-        'email': user.email,
-        'activation_key': gen_activation_key(user)
+        'ACTIVATION_HOURS': settings.ACTIVATION_HOURS,
     })
     subject = _('%(sitename)s – Activation of the user “%(name)s”') % {
         'sitename': settings.BASE_DOMAIN_NAME,
-        'name': user.username}
+        'name': user.username,
+    }
     send_mail(subject, message, settings.INYOKA_SYSTEM_USER_EMAIL, [user.email])
 
 

--- a/inyoka/portal/user.py
+++ b/inyoka/portal/user.py
@@ -443,9 +443,6 @@ class User(AbstractBaseUser, PermissionsMixin, GuardianUserMixin):
         elif action == 'activate':
             return href('portal', 'activate',
                         self.username, gen_activation_key(self), **query)
-        elif action == 'activate_delete':
-            return href('portal', 'delete',
-                        self.username, gen_activation_key(self), **query)
         elif action == 'admin':
             return href('portal', 'user', self.username, 'edit', *args, **query)
         elif action in ('subscribe', 'unsubscribe'):

--- a/jinja2/mails/activation_mail.txt
+++ b/jinja2/mails/activation_mail.txt
@@ -8,8 +8,7 @@ Es wurde ein Benutzerkonto registriert, und diese E-Mail-Adresse ({{ user.email 
 Das oben angesprochene Benutzerkonto ist im Moment inaktiv. Du kannst es erst benutzen, wenn du es durch Klicken auf folgenden Link aktiviert hast:
 {{ user.get_absolute_url('activate') }}
 
-Solltest du dieses Benutzerkonto nicht registriert haben, kannst du es unter folgendem Link wieder löschen:
-{{ user.get_absolute_url('activate_delete') }}
+Der Link ist 48 Stunden gültig. Danach wird ein inaktives Benutzerkonto gelöscht.
 
 Aus Sicherheitsgründen schicken wir Dir Dein Passwort in dieser E-Mail nicht mit und speichern dieses auch nicht im Klartext in unserer Datenbank. Wenn Du es vergisst, können wir Dir also nur ein neues schicken.
 

--- a/jinja2/mails/activation_mail.txt
+++ b/jinja2/mails/activation_mail.txt
@@ -8,7 +8,7 @@ Es wurde ein Benutzerkonto registriert, und diese E-Mail-Adresse ({{ user.email 
 Das oben angesprochene Benutzerkonto ist im Moment inaktiv. Du kannst es erst benutzen, wenn du es durch Klicken auf folgenden Link aktiviert hast:
 {{ user.get_absolute_url('activate') }}
 
-Der Link ist 48 Stunden gültig. Danach wird ein inaktives Benutzerkonto gelöscht.
+Der Link ist {{ ACTIVATION_HOURS }} Stunden gültig. Danach wird ein inaktives Benutzerkonto gelöscht.
 
 Aus Sicherheitsgründen schicken wir Dir Dein Passwort in dieser E-Mail nicht mit und speichern dieses auch nicht im Klartext in unserer Datenbank. Wenn Du es vergisst, können wir Dir also nur ein neues schicken.
 

--- a/tests/apps/portal/test_views.py
+++ b/tests/apps/portal/test_views.py
@@ -1566,31 +1566,13 @@ class TestActivate(TestCase):
         self.user = User.objects.register_user('user', 'user@example.com', 'user', False)
 
     def test_get__not_existing_user(self):
-        response = self.client.get('/delete/foobarbaz_user/test_key/', follow=True)
+        response = self.client.get('/activate/foobarbaz_user/test_key/', follow=True)
         self.assertContains(response, 'does not exist.')
 
     def test_get__logged_in(self):
         self.client.login(username='user', password='user')
-        response = self.client.get('/delete/user/test_key/', follow=True)
+        response = self.client.get('/activate/user/test_key/', follow=True)
         self.assertContains(response, 'You cannot enter an activation key when you are logged in.')
-
-    def test_get__delete__already_deleted(self):
-        key = gen_activation_key(self.user)
-        self.user.status = User.STATUS_INACTIVE
-        self.user.save()
-        response = self.client.get(f'/delete/user/{key}/', follow=True)
-        self.assertContains(response,'Your account was anonymized.')
-
-    def test_get__delete__already_active(self):
-        key = gen_activation_key(self.user)
-        response = self.client.get(f'/delete/user/{key}/', follow=True)
-        self.assertContains(response,
-                            'was already activated.')
-
-    def test_get__delete__invalid_key(self):
-        response = self.client.get('/delete/user/test_key/', follow=True)
-        self.assertContains(response,
-                            'Your activation key is invalid.')
 
     def test_get__activate(self):
         key = gen_activation_key(self.user)
@@ -1599,6 +1581,9 @@ class TestActivate(TestCase):
         response = self.client.get(f'/activate/user/{key}/', follow=True)
         self.assertContains(response,
                             'Your account was successfully activated.')
+
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.status, User.STATUS_ACTIVE)
 
     def test_get__activate__invalid_key(self):
         response = self.client.get('/activate/user/test_key/', follow=True)

--- a/tests/apps/portal/test_views.py
+++ b/tests/apps/portal/test_views.py
@@ -1585,6 +1585,22 @@ class TestActivate(TestCase):
         self.user.refresh_from_db()
         self.assertEqual(self.user.status, User.STATUS_ACTIVE)
 
+    def test_get__activate__already_active(self):
+        key = gen_activation_key(self.user)
+        self.user.status = User.STATUS_ACTIVE
+        self.user.save()
+        response = self.client.get(f'/activate/user/{key}/', follow=True)
+        self.assertContains(response,
+                            'Your activation key is invalid.')
+
+    def test_get__activate__user_banned(self):
+        key = gen_activation_key(self.user)
+        self.user.status = User.STATUS_BANNED
+        self.user.save()
+        response = self.client.get(f'/activate/user/{key}/', follow=True)
+        self.assertContains(response,
+                            'Your activation key is invalid.')
+
     def test_get__activate__invalid_key(self):
         response = self.client.get('/activate/user/test_key/', follow=True)
         self.assertContains(response,

--- a/tests/utils/test_user.py
+++ b/tests/utils/test_user.py
@@ -5,27 +5,40 @@
     :copyright: (c) 2007-2025 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from hashlib import sha1
-
 from django.conf import settings
+from django.test.utils import override_settings
+from freezegun import freeze_time
 
 from inyoka.portal.user import User
 from inyoka.utils.test import TestCase
-from inyoka.utils.user import gen_activation_key
+from inyoka.utils.user import gen_activation_key, check_activation_key
 
 
 class TestUtilsUser(TestCase):
-    def setUp(self):
-        super().setUp()
-        self.user = User.objects.register_user('testing', 'example@example.com',
-                                               'pwd', False)
 
+    @freeze_time('2025-01-20 13:13:37')
+    @override_settings(SECRET_KEY='FOOBAR_SECRETE_39q4utfhaer')
     def test_gen_activation_key(self):
-        # We need to fakly generate the hash here because we're using the
-        # user.id and MySQL does not handle primary keys well during
-        # unittests runs so that we get the wrong id here everytime.
-        # This way we cannot use a pregenerated key :(
-        to_hash = '%d%s%s%s' % (self.user.id, self.user.username, settings.SECRET_KEY, self.user.email)
-        hash = sha1(to_hash.encode()).hexdigest()  # sha1 needs bytes
+        u = User.objects.create(id=133337, username='testing', email='example@example.test')
 
-        self.assertEqual(gen_activation_key(self.user), hash)
+        self.assertEqual(
+            gen_activation_key(u),
+            'eyJ1c2VyX2lkIjoxMzMzMzcsInVzZXJuYW1lIjoidGVzdGluZyJ9:1tZraz:6jRPSJsiYTZKpBefCoQ4OO8-tBca6PFLFyGldrftAfM'
+        )
+
+    def test_check_activation_key(self):
+        u = User.objects.create(username='testing',
+                                email='example@example.test')
+
+        key = gen_activation_key(u)
+        self.assertTrue(check_activation_key(u, key))
+
+    def test_check_activation_key__expired(self):
+        u = User.objects.create(username='testing',
+                                email='example@example.test')
+
+        with freeze_time('2025-01-20 13:13:37'):
+            key = gen_activation_key(u)
+
+        with freeze_time('2026-01-01'): # a year later, the key should be invalid
+            self.assertFalse(check_activation_key(u, key))

--- a/tests/utils/test_user.py
+++ b/tests/utils/test_user.py
@@ -5,13 +5,12 @@
     :copyright: (c) 2007-2025 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
-from django.conf import settings
 from django.test.utils import override_settings
 from freezegun import freeze_time
 
 from inyoka.portal.user import User
 from inyoka.utils.test import TestCase
-from inyoka.utils.user import gen_activation_key, check_activation_key
+from inyoka.utils.user import check_activation_key, gen_activation_key
 
 
 class TestUtilsUser(TestCase):


### PR DESCRIPTION
 - Remove possibility to delete inactive accounts (Accounts are only deleted via a celery task, but not by clicking on the link.)
 - Use django's signer for activation key (`gen_activation_key` still used sha1. Furthermore, the key had no time expiration.)

see commits for details.