### PR TITLE
Rework captcha

### DIFF
--- a/inyoka/portal/forms.py
+++ b/inyoka/portal/forms.py
@@ -137,9 +137,9 @@ class RegisterForm(forms.Form):
 
     Validates that the requested username is not already in use, and
     requires the password to be entered twice to catch typos.
-    The user also needs to confirm our terms of usage and there are some
-    techniques for bot catching included e.g a CAPTCHA and a hidden captcha
-    for bots that just fill out everything.
+    The user also needs to confirm our terms of usage, and there are some
+    techniques for bot catching included e.g. a CAPTCHA and a hidden captcha
+    for bots that just fill everything.
     """
     username = forms.CharField(label=gettext_lazy('Username'), max_length=20)
     email = EmailField(label=gettext_lazy('E-mail'),
@@ -152,10 +152,14 @@ class RegisterForm(forms.Form):
         widget=forms.PasswordInput(render_value=False))
     confirm_password = forms.CharField(label=gettext_lazy('Confirm password'),
         widget=forms.PasswordInput(render_value=False))
-    captcha = CaptchaField(label=gettext_lazy('CAPTCHA'))
+    # captcha see __init__
     terms_of_usage = forms.BooleanField()
 
     use_required_attribute = False
+
+    def __init__(self, session=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['captcha'] = CaptchaField(session=session, label=gettext_lazy('CAPTCHA'))
 
     def clean_username(self):
         """

--- a/inyoka/portal/services.py
+++ b/inyoka/portal/services.py
@@ -9,14 +9,11 @@
     :license: BSD, see LICENSE for more details.
 """
 import time
-from hashlib import md5
 
-from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db.models.functions import Length
 
 from inyoka.portal.user import User
-from inyoka.utils.captcha import Captcha
 from inyoka.utils.services import SimpleDispatcher
 
 MIN_AUTOCOMPLETE_CHARS = 3
@@ -53,18 +50,6 @@ def get_group_autocompletion(request):
                               .order_by(Length('name').asc())\
                               .values_list('name', flat=True)[:MAX_AUTOCOMPLETE_ITEMS]
     return list(groupnames)
-
-
-@dispatcher.register()
-def get_captcha(request):
-    captcha = Captcha()
-    h = md5(settings.SECRET_KEY.encode())
-    h.update(captcha.solution.encode())
-    request.session['captcha_solution'] = h.hexdigest()
-    response = captcha.get_response()
-    # Save the solution for easier testing
-    response._captcha_solution = captcha.solution
-    return response
 
 
 @dispatcher.register()

--- a/inyoka/portal/templates/forms/widgets/image_captcha.html
+++ b/inyoka/portal/templates/forms/widgets/image_captcha.html
@@ -1,7 +1,7 @@
 {# uses django template engine #}
 {% load i18n %}
 
-<img src="{{ widget.captcha_url }}" class="captcha" alt="{% trans 'CAPTCHA' %}" />
+<img src="{{ widget.captcha_img }}" class="captcha" alt="{% trans 'CAPTCHA' %}" />
 <input type="submit" name="renew_captcha" value="{% trans 'Generate new code' %}" />
 
 <br>

--- a/inyoka/utils/captcha.py
+++ b/inyoka/utils/captcha.py
@@ -10,13 +10,14 @@
     :copyright: (c) by Micah Dowty.
     :license: BSD, see LICENSE for more details.
 """
+import base64
 import colorsys
+import io
 import math
 import random
 from os import listdir
 from os.path import abspath, dirname, join, pardir
 
-from django.http import HttpResponse
 from PIL import Image, ImageChops, ImageColor, ImageDraw, ImageFont
 
 resource_path = abspath(join(dirname(__file__), pardir, 'res'))
@@ -85,10 +86,11 @@ class Captcha:
             image = layer.render(image)
         return image
 
-    def get_response(self, size=None):
-        response = HttpResponse(content_type='image/webp')
-        self.render_image(size=size).save(response, 'WebP')
-        return response
+    def get_base64_image(self, size=None) -> str:
+        buffer = io.BytesIO()
+        self.render_image(size=size).save(buffer, 'WebP')
+        img_base64 = base64.b64encode(buffer.getvalue()).decode()
+        return f"data:image/webp;base64,{img_base64}"
 
 
 class Layer:

--- a/inyoka/utils/captcha.py
+++ b/inyoka/utils/captcha.py
@@ -86,8 +86,8 @@ class Captcha:
         return image
 
     def get_response(self, size=None):
-        response = HttpResponse(content_type='image/png')
-        self.render_image(size=None).save(response, 'PNG')
+        response = HttpResponse(content_type='image/webp')
+        self.render_image(size=size).save(response, 'WebP')
         return response
 
 

--- a/inyoka/utils/forms.py
+++ b/inyoka/utils/forms.py
@@ -8,27 +8,26 @@
     :copyright: (c) 2007-2025 by the Inyoka Team, see AUTHORS for more details.
     :license: BSD, see LICENSE for more details.
 """
+import hashlib
+import logging
 import re
-import sys
 import urllib.error
 import urllib.parse
 import urllib.request
-from hashlib import md5
-from random import randrange
 
 from django import forms
 from django.conf import settings
 from django.core import validators
+from django.core.cache import cache
 from django.forms import DateInput, MultipleChoiceField, SplitDateTimeWidget, TimeInput
 from django.forms.widgets import TextInput
 from django.utils.translation import gettext as _
 
 from inyoka.markup.base import StackExhaused, parse
-from inyoka.utils.local import current_request
+from inyoka.utils.captcha import Captcha
 from inyoka.utils.mail import is_blocked_host
 from inyoka.utils.sessions import SurgeProtectionMixin
 from inyoka.utils.text import slugify
-from inyoka.utils.urls import href
 
 
 def clear_surge_protection(request, form):
@@ -249,6 +248,9 @@ class SlugField(forms.CharField):
 
 
 class HiddenCaptchaField(forms.Field):
+    """
+    A hidden field intended to catch some bots that simply fill every field with some content.
+    """
     widget = forms.HiddenInput
 
     def __init__(self, *args, **kwargs):
@@ -265,6 +267,10 @@ class HiddenCaptchaField(forms.Field):
 
 
 class ImageCaptchaWidget(TextInput):
+    """
+    A text input where users enter the captcha value of the associated captcha image.
+    The Latter is also rendered in this class.
+    """
     template_name = 'forms/widgets/image_captcha.html'
 
     class Media:
@@ -272,58 +278,112 @@ class ImageCaptchaWidget(TextInput):
             "all": ["style/captcha.css"],
         }
 
+    def __init__(self, captcha_img, *args, **kwargs):
+        self.captcha_img = captcha_img
+        super().__init__(*args, **kwargs)
+
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
-        context['widget']['captcha_url'] = href('portal', __service__='portal.get_captcha',
-                                                rnd=randrange(1, sys.maxsize))
+        context['widget']['captcha_img'] = self.captcha_img
         return context
 
 
 class ImageCaptchaField(forms.Field):
-    widget = ImageCaptchaWidget
+    """
+    Field that checks if the entered value fits the captcha solution.
+    """
 
-    def __init__(self, *args, **kwargs):
-        forms.Field.__init__(self, *args, **kwargs)
+    def __init__(self, captcha_solution, *args, **kwargs):
+        self.solution = captcha_solution
+
+        super().__init__(*args, **kwargs)
 
     def clean(self, value):
         value = super().clean(value)
-        solution = current_request.session.get('captcha_solution')
-        if value:
-            h = md5(settings.SECRET_KEY.encode())
-            if value:
-                h.update(value.encode())
-            if h.hexdigest() == solution:
-                return True
+
+        if value and value == self.solution:
+            return True
         raise forms.ValidationError(_('The entered CAPTCHA was incorrect.'))
 
 
 class CaptchaWidget(forms.MultiWidget):
-    def __init__(self, attrs=None):
-        # The HiddenInput is a honey-pot
-        widgets = ImageCaptchaWidget, forms.HiddenInput
+    """
+    Custom widget for CaptchaField.
+    """
+    def __init__(self, captcha_img, attrs=None):
+        """
+        Pass a `captcha_img` from the parent captcha field to the widget.
+
+        The HiddenInput is a honey-pot.
+        """
+        widgets = ImageCaptchaWidget(captcha_img), forms.HiddenInput
         super().__init__(widgets, attrs)
 
     def decompress(self, value):
+        """
+        Decompress always defaults to empty, as the user should enter the captcha
+        (like a password) and the hidden input should always be empty.
+        """
         return [None, None]
 
 
 class CaptchaField(forms.MultiValueField):
-    widget = CaptchaWidget
+    """
+    Allows adding a captcha to a form. It consists of two fields:
 
-    def __init__(self, *args, **kwargs):
-        kwargs['required'] = True
-        self.only_anonymous = kwargs.pop('only_anonymous', False)
-        fields = (ImageCaptchaField(), HiddenCaptchaField())
+     * a field to insert the value of the captcha. It also includes the captcha image.
+     * a hidden field intended to catch some bots that simply fill every field with some content.
+
+    Instantiate a `CaptchaField` in the `__init__` of the form, because this field needs
+    the current user session as an init-parameter.
+    """
+
+    def __init__(self, session, *args, **kwargs) -> None:
+        self.session = session
+        self.captcha = cache.get_or_set(self._session_cache_key(), Captcha)
+        logging.debug(f'captcha solution {self.captcha.solution}')
+
+        self.widget = CaptchaWidget(captcha_img=self.captcha.get_base64_image())
+        kwargs['require_all_fields'] = False # HiddenCaptchaField is not required
+        fields = (
+            ImageCaptchaField(captcha_solution=self.captcha.solution),
+            HiddenCaptchaField(),
+        )
         super().__init__(fields, *args, **kwargs)
 
-    def compress(self, data_list):
-        pass  # CaptchaField doesn't have a useful value to return.
+    def compress(self, data_list) -> bool:
+        """
+        Returns, whether the captcha was filled valid. If all fields are valid,
+        both should return `True`.
 
-    def clean(self, value):
-        if current_request.user.is_authenticated and self.only_anonymous:
-            return [None, None]
-        value[1] = False  # Prevent being caught by validators.EMPTY_VALUES
-        return super().clean(value)
+        In case of an error, `ImageCaptchaField` and `HiddenCaptchaField` raise
+        a `ValidationError` themselves.
+        """
+        return all(data_list)
+
+    def _session_cache_key(self) -> str:
+        """Returns a unique cache key. The key is scoped to the portal."""
+        return f'/portal/captcha/{self._session_hash()}'
+
+    def _session_hash(self) -> str:
+        """
+        Returns a unique checksum for the current session.
+        It is used for a unique cache key.
+        """
+        session_hash = hashlib.sha256()
+        session_hash.update(self.session.session_key.encode())
+        return session_hash.hexdigest()
+
+    def delete_cached_captcha(self) -> None:
+        """
+        Allows views to rotate the captcha (e.g., if it was successfully used or
+        the user requests another one).
+
+        This will just remove the captcha of the associated session. Thus, on the next
+        request a new captcha is created.
+        """
+        cache.delete(self._session_cache_key())
+        self.captcha = None
 
 
 class TopicField(forms.CharField):

--- a/tests/apps/portal/test_views.py
+++ b/tests/apps/portal/test_views.py
@@ -394,183 +394,6 @@ class TestAuthViews(TestCase):
         # But internal redirects are fine.
         self.assertRedirects(response, 'http://' + settings.BASE_DOMAIN_NAME + '/calendar/')
 
-    def test_register_safe_redirects(self):
-        """External redirects are not allowed after visiting the register page.
-
-        For convenience, users will be redirected to the page they came from
-        when they visited the register page, but this does not include external
-        pages. This test makes sure that such a redirect will fail while
-        internal ones should work.
-        """
-        self.client.login(username='user', password='user')
-        next = 'http://google.at'
-        response = self.client.get('/register/', {'next': next}, follow=True)
-        # We don't allow redirects to external pages!
-        self.assertRedirects(response, 'http://' + settings.BASE_DOMAIN_NAME + '/')
-
-        next = 'http://%s/calendar/' % settings.BASE_DOMAIN_NAME
-        response = self.client.get('/register/', {'next': next}, follow=True)
-        # But internal redirects are fine.
-        self.assertRedirects(response, 'http://' + settings.BASE_DOMAIN_NAME + '/calendar/')
-
-    def test_register_as_authenticated_user(self):
-        """Logged in users shall not be able to register a new account."""
-        self.client.login(username='user', password='user')
-        with translation.override('en-us'):
-            response = self.client.get('/register/', follow=True)
-        self.assertContains(response, 'You are already logged in.')
-
-    def test_register(self):
-        """Test the process of registering a new account.
-
-        Checks if an email is send to activate the new account.
-        """
-        logging.debug(self.client.session.session_key) # otherwise, None in CaptchaField
-
-        self.client.get('/register/') # fill cache with captcha
-
-        captcha = cache.get(CaptchaField(self.client.session)._session_cache_key())
-        postdata = {
-            'username': 'apollo13',
-            'password': 'secret',
-            'confirm_password': 'secret',
-            'email': 'apollo13@example.com',
-            'terms_of_usage': '1',
-            'captcha_0': captcha.solution,
-            'captcha_1': ''
-        }
-
-        self.assertEqual(0, len(mail.outbox))
-        with translation.override('en-us'):
-            self.client.post('/register/', postdata)
-        self.assertEqual(1, len(mail.outbox))
-        subject = mail.outbox[0].subject
-        self.assertIn('Activation of the user “apollo13”', subject)
-
-    def test_register_deactivated(self):
-        """Test the process of registering a new account.
-
-        Checks that a disabled registration doesn't allow registering new users.
-        """
-        with override_settings(INYOKA_DISABLE_REGISTRATION=True):
-            with translation.override('en-us'):
-                response = self.client.get('/register/', follow=True)
-        self.assertRedirects(response, href('portal'))
-        self.assertContains(response, 'User registration is currently disabled.')
-
-    def test_register_contains_captcha(self):
-        """The captcha is rendered via an own `ImageCaptchaWidget`"""
-        logging.debug(self.client.session.session_key) # otherwise, None in CaptchaField
-
-        response = self.client.get('/register/')
-        self.assertContains(response, '<img src="data:image/')
-
-    def test_register__renew_captcha(self):
-        """
-        The captcha should change, if the user requested so via a button.
-        """
-        regex = '<img src="(?P<encoded_img>data:image.*)" class'
-
-        logging.debug(self.client.session.session_key) # otherwise, None in CaptchaField
-        self.client.get('/register/') # session changes after first request, but is stable afterwards...
-
-        response = self.client.get('/register/')
-        base64_img = re.search(regex, response.content.decode(), re.MULTILINE).group('encoded_img')
-        solution1 = response.context['form'].fields['captcha'].captcha.solution
-
-        postdata = {
-            'renew_captcha': '1',
-        }
-        response = self.client.post('/register/', postdata)
-        base64_img_2 = re.search(regex, response.content.decode(), re.MULTILINE).group('encoded_img')
-        solution2 = response.context['form'].fields['captcha'].captcha.solution
-
-        with self.subTest('captcha solution differs'):
-            self.assertNotEqual(solution1, solution2)
-        with self.subTest('image differs'):
-            self.assertNotEqual(base64_img, base64_img_2)
-
-    def test_register__two_get_same_captcha_solution(self):
-        """
-        If the captcha was not used, display the same captcha for the same session.
-        """
-        logging.debug(self.client.session.session_key)
-        self.client.get('/register/') # session changes after first request, but is stable afterwards...
-
-        response = self.client.get('/register/')
-        solution1 = response.context['form'].fields['captcha'].captcha.solution
-
-        response = self.client.get('/register/')
-        solution2 = response.context['form'].fields['captcha'].captcha.solution
-
-        self.assertEqual(solution1, solution2)
-
-    def test_register__new_captcha_after_successful_submission(self):
-        """
-        The same captcha should be only usable for one registration.
-        After a person successfully registered, display a different captcha.
-        """
-        logging.debug(self.client.session.session_key)
-        self.client.get('/register/') # session changes after first request, but is stable afterwards...
-
-        captcha = cache.get(CaptchaField(self.client.session)._session_cache_key())
-        solution1 = captcha.solution
-        postdata = {
-            'username': 'apollo13',
-            'password': 'secret',
-            'confirm_password': 'secret',
-            'email': 'apollo13@example.com',
-            'terms_of_usage': '1',
-            'captcha_0': solution1,
-            'captcha_1': ''
-        }
-        self.client.post('/register/', postdata)
-
-        response = self.client.get('/register/')
-        solution2 = response.context['form'].fields['captcha'].captcha.solution
-
-        self.assertNotEqual(solution1, solution2)
-
-    def test_register__wrong_captcha(self):
-        logging.debug(self.client.session.session_key)
-        postdata = {
-            'captcha_0': 'foobar',
-        }
-        response = self.client.post('/register/', postdata)
-
-        self.assertFormError(response.context['form'], 'captcha', errors=['The entered CAPTCHA was incorrect.'])
-
-    def test_register__bot_field(self):
-        """
-        If the second captcha field is filled with content, display a message
-        that the user was classified as a bot.
-        """
-        logging.debug(self.client.session.session_key)
-
-        captcha = cache.get(CaptchaField(self.client.session)._session_cache_key())
-        postdata = {
-            'password': 'secret',
-            'confirm_password': 'secret',
-            'captcha_0': captcha.solution,
-            'captcha_1': 'foobar',
-        }
-        response = self.client.post('/register/', postdata)
-
-        self.assertFormError(response.context['form'], None, errors=[])
-        self.assertFormError(response.context['form'], 'captcha', errors=['You have entered an invisible field and were therefore classified as a bot.'])
-
-    def test_register__missing_captcha(self):
-        logging.debug(self.client.session.session_key)
-
-        postdata = {
-            'password': 'secret',
-            'confirm_password': 'secret',
-        }
-        response = self.client.post('/register/', postdata)
-
-        self.assertFormError(response.context['form'], None, errors=[])
-        self.assertFormError(response.context['form'], 'captcha', errors=['This field is required.'])
-
     def test_lost_password(self):
         """Test the “lost password” feature.
 
@@ -761,6 +584,175 @@ class TestRegister(TestCase):
 
         self.assertEqual(form.errors['username'],
                          ['Please do not enter an email address as username.'])
+
+    def test_safe_redirects(self):
+        """External redirects are not allowed after visiting the register page.
+
+        For convenience, users will be redirected to the page they came from
+        when they visited the register page, but this does not include external
+        pages. This test makes sure that such a redirect will fail while
+        internal ones should work.
+        """
+        User.objects.register_user('user', 'user@example.com', 'user', False)
+        self.client.login(username='user', password='user')
+
+        next = 'http://google.at'
+        response = self.client.get('/register/', {'next': next}, follow=True)
+        # We don't allow redirects to external pages!
+        self.assertRedirects(response, 'http://' + settings.BASE_DOMAIN_NAME + '/')
+
+        next = 'http://%s/calendar/' % settings.BASE_DOMAIN_NAME
+        response = self.client.get('/register/', {'next': next}, follow=True)
+        # But internal redirects are fine.
+        self.assertRedirects(response, 'http://' + settings.BASE_DOMAIN_NAME + '/calendar/')
+
+    def test_as_authenticated_user(self):
+        """Logged-in users shall not be able to register a new account."""
+        User.objects.register_user('user', 'user@example.com', 'user', False)
+        self.client.login(username='user', password='user')
+
+        with translation.override('en-us'):
+            response = self.client.get('/register/', follow=True)
+        self.assertContains(response, 'You are already logged in.')
+
+    def test_register(self):
+        """Test the process of registering a new account.
+
+        Checks if an email is sent to activate the new account.
+        """
+        self.client.get('/register/') # fill cache with captcha
+
+        captcha = cache.get(CaptchaField(self.client.session)._session_cache_key())
+        postdata = {
+            'username': 'apollo13',
+            'password': 'secret',
+            'confirm_password': 'secret',
+            'email': 'apollo13@example.com',
+            'terms_of_usage': '1',
+            'captcha_0': captcha.solution,
+            'captcha_1': ''
+        }
+
+        self.assertEqual(0, len(mail.outbox))
+        with translation.override('en-us'):
+            self.client.post('/register/', postdata)
+        self.assertEqual(1, len(mail.outbox))
+        subject = mail.outbox[0].subject
+        self.assertIn('Activation of the user “apollo13”', subject)
+
+    def test_register_deactivated(self):
+        """Test the process of registering a new account.
+
+        Checks that a disabled registration doesn't allow registering new users.
+        """
+        with override_settings(INYOKA_DISABLE_REGISTRATION=True):
+            with translation.override('en-us'):
+                response = self.client.get('/register/', follow=True)
+        self.assertRedirects(response, href('portal'))
+        self.assertContains(response, 'User registration is currently disabled.')
+
+    def test_contains_captcha(self):
+        """The captcha is rendered via an own `ImageCaptchaWidget`"""
+        response = self.client.get('/register/')
+        self.assertContains(response, '<img src="data:image/')
+
+    def test__renew_captcha(self):
+        """
+        The captcha should change if the user requested so via a button.
+        """
+        regex = '<img src="(?P<encoded_img>data:image.*)" class'
+
+        self.client.get('/register/') # session changes after first request, but is stable afterwards...
+
+        response = self.client.get('/register/')
+        base64_img = re.search(regex, response.content.decode(), re.MULTILINE).group('encoded_img')
+        solution1 = response.context['form'].fields['captcha'].captcha.solution
+
+        postdata = {
+            'renew_captcha': '1',
+        }
+        response = self.client.post('/register/', postdata)
+        base64_img_2 = re.search(regex, response.content.decode(), re.MULTILINE).group('encoded_img')
+        solution2 = response.context['form'].fields['captcha'].captcha.solution
+
+        with self.subTest('captcha solution differs'):
+            self.assertNotEqual(solution1, solution2)
+        with self.subTest('image differs'):
+            self.assertNotEqual(base64_img, base64_img_2)
+
+    def test_two_get_same_captcha_solution(self):
+        """
+        If the captcha was not used, display the same captcha for the same session.
+        """
+        self.client.get('/register/') # session changes after first request, but is stable afterwards...
+
+        response = self.client.get('/register/')
+        solution1 = response.context['form'].fields['captcha'].captcha.solution
+
+        response = self.client.get('/register/')
+        solution2 = response.context['form'].fields['captcha'].captcha.solution
+
+        self.assertEqual(solution1, solution2)
+
+    def test_new_captcha_after_successful_submission(self):
+        """
+        The same captcha should be only usable for one registration.
+        After a person successfully registered, display a different captcha.
+        """
+        self.client.get('/register/') # session changes after first request, but is stable afterwards...
+
+        captcha = cache.get(CaptchaField(self.client.session)._session_cache_key())
+        solution1 = captcha.solution
+        postdata = {
+            'username': 'apollo13',
+            'password': 'secret',
+            'confirm_password': 'secret',
+            'email': 'apollo13@example.com',
+            'terms_of_usage': '1',
+            'captcha_0': solution1,
+            'captcha_1': ''
+        }
+        self.client.post('/register/', postdata)
+
+        response = self.client.get('/register/')
+        solution2 = response.context['form'].fields['captcha'].captcha.solution
+
+        self.assertNotEqual(solution1, solution2)
+
+    def test__wrong_captcha(self):
+        postdata = {
+            'captcha_0': 'foobar',
+        }
+        response = self.client.post('/register/', postdata)
+
+        self.assertFormError(response.context['form'], 'captcha', errors=['The entered CAPTCHA was incorrect.'])
+
+    def test_bot_field(self):
+        """
+        If the second captcha field is filled with content, display a message
+        that the user was classified as a bot.
+        """
+        captcha = cache.get(CaptchaField(self.client.session)._session_cache_key())
+        postdata = {
+            'password': 'secret',
+            'confirm_password': 'secret',
+            'captcha_0': captcha.solution,
+            'captcha_1': 'foobar',
+        }
+        response = self.client.post('/register/', postdata)
+
+        self.assertFormError(response.context['form'], None, errors=[])
+        self.assertFormError(response.context['form'], 'captcha', errors=['You have entered an invisible field and were therefore classified as a bot.'])
+
+    def test__missing_captcha(self):
+        postdata = {
+            'password': 'secret',
+            'confirm_password': 'secret',
+        }
+        response = self.client.post('/register/', postdata)
+
+        self.assertFormError(response.context['form'], None, errors=[])
+        self.assertFormError(response.context['form'], 'captcha', errors=['This field is required.'])
 
 
 class TestPasswordChangeView(TestCase):


### PR DESCRIPTION
Instead via a service, the captcha image is now send via HTML (inline, base64 decoded)

Instead of storing the solution into the session (for Inyoka by default a cookie), the solution is saved in the server-side cache.

see commits and inline comments for details.