### PR TITLE
Add subresource integrity to trianglify

### DIFF
--- a/inyoka/static/img/head/create_trianglify.html
+++ b/inyoka/static/img/head/create_trianglify.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <body>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/trianglify/2.0.0/trianglify.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/trianglify/2.0.0/trianglify.min.js" integrity="sha384-N/On7QTqcSk0h72Y7UtfNc3VdCCVFl5onCH5tP0GvJt/UUd3qg4FhMp2EFK8hHvX" crossorigin="anonymous"></script>
 <script>
 	var pattern = Trianglify({
 		width: 1900,


### PR DESCRIPTION
Even if it is just used to created the background once, try subresource integrity.