### PR TITLE
Revert "Quickfix, CI: Allow BDD selenium tests to fail"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,8 @@ jobs:
         127.0.0.1       ubuntuusers.local forum.ubuntuusers.local paste.ubuntuusers.local wiki.ubuntuusers.local planet.ubuntuusers.local ikhaya.ubuntuusers.local static.ubuntuusers.local media.ubuntuusers.local
         __EOF__
         python manage.py collectstatic --noinput
-        coverage run -m behave --tags=-skip
+        sudo apt-get install retry
+        retry --times=3 -- coverage run -m behave --tags=-skip
         coverage html -d bdd_coverage
     - name: Save BDD results
       if: ${{ matrix.database == 'postgresql' }}


### PR DESCRIPTION
This reverts commit b0775d373162ea5f4230b098043ecf34a4546137.

Fix https://github.com/inyokaproject/inyoka/issues/1424