### PR TITLE
Privmsg: Fix UnboundLocalError with invalid action

### DIFF
--- a/inyoka/portal/views.py
+++ b/inyoka/portal/views.py
@@ -982,6 +982,8 @@ def privmsg(request, folder=None, entry_id=None, page=1, one_page=False):
                 elif action == 'delete':
                     msg = _('Do you really want to delete the message?')
                     confirm_label = _('Delete')
+                else:
+                    raise Http404('invalid action parameter')
                 flash_message(request, 'confirm_action_flash.html', {
                     'message': msg,
                     'confirm_label': confirm_label,

--- a/tests/apps/portal/test_views.py
+++ b/tests/apps/portal/test_views.py
@@ -817,6 +817,18 @@ class TestPrivMsgViews(TestCase):
         response = self.client.get('/privmsg/42/')
         self.assertEqual(response.status_code, 404)
 
+
+    def test_invalid_action(self):
+        pm1 = PrivateMessage.objects.create(author=self.user, subject='Subject',
+                                            text='Text', pub_date=dj_timezone.now())
+        PrivateMessageEntry.objects.create(message=pm1, user=self.user,
+                                           read=False,
+                                           folder=PRIVMSG_FOLDERS['sent'][0])
+
+        url = f'http://{settings.BASE_DOMAIN_NAME}/privmsg/sent/{pm1.id}/?action=invalidaction'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)
+
     def test_delete_many(self):
         user2 = User.objects.register_user('user2', 'user2@example.com', 'user', False)
         pm1 = PrivateMessage.objects.create(author=user2, subject='Subject',


### PR DESCRIPTION
Instead of trying to show a msg, if the action is invalid, raise a HTTP 404.

Trace in sentry was
```
Traceback (most recent call last):
  File "django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "django/contrib/auth/decorators.py", line 59, in _view_wrapper
    return view_func(request, *args, **kwargs)
  File "inyoka/utils/http.py", line 38, in proxy
    rv = f(request, *args, **kwargs)
  File "inyoka/portal/views.py", line 968, in privmsg
    'message': msg,
UnboundLocalError: cannot access local variable 'msg' where it is not associated with a value
```