### PR TITLE
Reintroduce retry for BDD tests in CI (with timeout)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,8 @@ jobs:
         127.0.0.1       ubuntuusers.local forum.ubuntuusers.local paste.ubuntuusers.local wiki.ubuntuusers.local planet.ubuntuusers.local ikhaya.ubuntuusers.local static.ubuntuusers.local media.ubuntuusers.local
         __EOF__
         python manage.py collectstatic --noinput
-        coverage run -m behave --tags=-skip
+        sudo apt-get update && sudo apt-get install retry
+        retry --times=3 -- timeout 10m coverage run -m behave --tags=-skip
         coverage html -d bdd_coverage
     - name: Save BDD results
       if: ${{ matrix.database == 'postgresql' }}


### PR DESCRIPTION
There was already a retry for the BDD tests
(commit 56e201ac7b0dfd38bc7f33fe421b19f93ff1b51b)

After the switch to firefox headless it worked without a retry (commit 4851854ac4698087b8bf62e88d01f817d6217b08)

However, now python 3.13 with postgresql seems to never terminate sporatically.

Thus, a retry is reintroduced. Now with a timeout of 10 minutes per coverage run. Normally, the BDD tests take a maxmium of 3 minutes in github actions to succceed.